### PR TITLE
chore(deno): remove stabilized unstable flags

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,7 +27,8 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: release-drafter/release-drafter@v7
         with:
-           config-name: release-drafter-config.yml
-           disable-autolabeler: false
+          config-name: release-drafter-config.yml
+          commitish: ${{ github.event.repository.default_branch }}
+          publish: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,6 @@
       "runtimeArgs": [
         "run",
         "-P",
-        "--unstable",
         "--allow-scripts=npm:protobufjs",
         "--inspect-wait"
       ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,10 +11,7 @@
   "editor.formatOnSave": true,
   "deno.codeLens.testArgs": [
     "--allow-all",
-    "--no-check",
-    "--unstable-experimentalDecorators",
-    "--unstable-emitDecoratorMetadata",
-    "--unstable-temporal"
+    "--no-check"
   ],
   "chat.tools.terminal.autoApprove": {
     "cd": true,

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@
 	- `--unstable-temporal`
 	- `--unstable-experimentalDecorators`
 	- `--unstable-emitDecoratorMetadata`
-- Kept `--unstable-otel` and `--unstable-cron` in tasks for now pending a separate follow-up validation.
+- Removed `--unstable-otel` and `--unstable-cron` after Phase 2 validation:
+	- `deno compile` works without both flags
+	- app startup and OpenTelemetry bootstrap succeed without both flags
 
 ## Quality gates
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Getting started
 
 1. **Install prerequisites**
-	 - [Deno **2.5.4**](https://deno.land/) or newer (matches CI `denoland/setup-deno@v2` pin).
+	 - [Deno **2.7.10**](https://deno.land/) or newer (matches CI `denoland/setup-deno@v2` pin).
 	 - Optional: Docker for local MongoDB if you want realistic persistence.
 2. **Clone & configure**
 	 ```bash
@@ -44,6 +44,14 @@
 	```
 
 `bootstrap.ts` ensures graceful shutdown on `SIGINT`/`SIGTERM` and will clean up active timers before exit.
+
+## Deno 2.7 stabilization notes
+
+- Removed deprecated unstable flags for stabilized features:
+	- `--unstable-temporal`
+	- `--unstable-experimentalDecorators`
+	- `--unstable-emitDecoratorMetadata`
+- Kept `--unstable-otel` and `--unstable-cron` in tasks for now pending a separate follow-up validation.
 
 ## Quality gates
 

--- a/deno.json
+++ b/deno.json
@@ -70,11 +70,11 @@
     "deps:latest:show": "deno outdated --latest",
     "deps:stable:update": "deno outdated --compatible --update !npm:zod",
     "deps:latest:update": "deno outdated --latest --update !npm:zod",
-    "dev": "deno -P --unstable-otel --unstable-cron bootstrap.ts",
-    "dev:watch": "deno -P --unstable-otel --unstable-cron --watch-hmr bootstrap.ts",
-    "swagger:generate": "deno -P --unstable-otel --unstable-cron src/swagger.ts",
+    "dev": "deno -P bootstrap.ts",
+    "dev:watch": "deno -P --watch-hmr bootstrap.ts",
+    "swagger:generate": "deno -P src/swagger.ts",
     "test": "deno test -P --coverage=coverage --allow-sys=osRelease",
-    "build": "deno compile -P --ignore-read --unstable-otel --unstable-cron --output=./build/edge bootstrap.ts"
+    "build": "deno compile -P --ignore-read --output=./build/edge bootstrap.ts"
   },
   "permissions": {
     "default": {

--- a/deno.json
+++ b/deno.json
@@ -70,11 +70,11 @@
     "deps:latest:show": "deno outdated --latest",
     "deps:stable:update": "deno outdated --compatible --update !npm:zod",
     "deps:latest:update": "deno outdated --latest --update !npm:zod",
-    "dev": "deno -P --unstable-otel --unstable-cron --unstable-temporal bootstrap.ts",
-    "dev:watch": "deno -P --unstable-otel --unstable-cron --unstable-temporal --watch-hmr bootstrap.ts",
-    "swagger:generate": "deno -P --unstable-otel --unstable-cron --unstable-temporal src/swagger.ts",
-    "test": "deno test -P --coverage=coverage --allow-sys=osRelease -- --unstable-experimentalDecorators --unstable-emitDecoratorMetadata",
-    "build": "deno compile -P --ignore-read --unstable-otel --unstable-cron --unstable-temporal --output=./build/edge bootstrap.ts"
+    "dev": "deno -P --unstable-otel --unstable-cron bootstrap.ts",
+    "dev:watch": "deno -P --unstable-otel --unstable-cron --watch-hmr bootstrap.ts",
+    "swagger:generate": "deno -P --unstable-otel --unstable-cron src/swagger.ts",
+    "test": "deno test -P --coverage=coverage --allow-sys=osRelease",
+    "build": "deno compile -P --ignore-read --unstable-otel --unstable-cron --output=./build/edge bootstrap.ts"
   },
   "permissions": {
     "default": {

--- a/src/package/series/repository/series.repository.test.ts
+++ b/src/package/series/repository/series.repository.test.ts
@@ -17,7 +17,7 @@ describe('SeriesRepository helpers', () => {
     assertEquals(result, null);
   });
 
-  // TODO: Enable this when --unstable-temporal issue is resolved
+  // TODO: Re-enable once Temporal cache TTL test behavior is fixed
   it.skip('persist and load round-trip', async () => {
     const collection = new InMemoryCollection<SeriesDocument>();
     const anilist = 12345;
@@ -78,7 +78,7 @@ describe('SeriesRepository helpers', () => {
     assertEquals(loaded?.title.english, 'Test Series');
   });
 
-  // TODO: Enable this when --unstable-temporal issue is resolved
+  // TODO: Re-enable once Temporal cache TTL test behavior is fixed
   it.skip('load returns null for stale document (48h+ old)', async () => {
     const collection = new InMemoryCollection<SeriesDocument>();
     const anilist = 54321;


### PR DESCRIPTION
# AniTrend Pull Request

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/AniTrend/on-the-edge/blob/dev/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure you've done the following:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- You have followed our [**contributing guidelines**](https://github.com/AniTrend/on-the-edge/blob/dev/CONTRIBUTING.md)
- Double checked that your branch is based on `dev` and targets `dev` (where applicable)
- Pull request has tests (if applicable)
- Documentation is updated (if necessary)
- Description explains the issue/use-case resolved


## Description
<!--- Describe your changes in detail, or link an existing issue here -->
Drop Deno flags that became stable in 2.7 from local test args and project tasks. This keeps runtime behavior the same while reducing noise from obsolete unstable options.

Also align README prerequisites to Deno 2.7.10 and document the Phase 1 migration scope, while leaving otel/cron flags unchanged, for follow-up validation.

<!--- Be kind to code reviewers, and please try to keep pull requests as small and focused as possible :) -->

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [Apache License, Version 2.0](https://github.com/AniTrend/on-the-edge/blob/dev/LICENSE.md).
