### PR TITLE
fix(bootstrap): test shutdown signal handling

### DIFF
--- a/bootstrap.signal.test.ts
+++ b/bootstrap.signal.test.ts
@@ -1,0 +1,66 @@
+import { assert, assertEquals } from '@std/assert';
+
+const FIXTURE_PATH = 'tests/fixtures/signal_runtime_fixture.ts';
+type ShutdownSignal = 'SIGINT' | 'SIGTERM';
+
+const readStream = async (stream: ReadableStream<Uint8Array> | null) => {
+  if (!stream) return '';
+  return await new Response(stream).text();
+};
+
+const readUntil = async (
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  expected: string,
+) => {
+  const decoder = new TextDecoder();
+  let output = '';
+
+  while (!output.includes(expected)) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    output += decoder.decode(value, { stream: true });
+  }
+
+  return output;
+};
+
+const assertSignalShutdown = async (signal: ShutdownSignal) => {
+  const child = new Deno.Command('/bin/sh', {
+    args: ['-c', `deno run -P ${FIXTURE_PATH} --signal=${signal}`],
+    stdout: 'piped',
+    stderr: 'piped',
+  }).spawn();
+
+  const reader = child.stdout!.getReader();
+  let stdout = await readUntil(reader, 'fixture-ready');
+
+  child.kill(signal);
+
+  const status = await child.status;
+  const remainder = await readStream(new ReadableStream({
+    async start(controller) {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        controller.enqueue(value);
+      }
+      controller.close();
+      reader.releaseLock();
+    },
+  }));
+  stdout += remainder;
+  const stderr = await readStream(child.stderr);
+
+  assertEquals(status.success, true, stderr);
+  assert(stdout.includes(`received:${signal}`));
+  assert(stdout.includes('close-called'));
+  assert(stdout.includes('cleanup-complete'));
+};
+
+Deno.test('process handles SIGTERM and exits cleanly', async () => {
+  await assertSignalShutdown('SIGTERM');
+});
+
+Deno.test('process handles SIGINT and exits cleanly', async () => {
+  await assertSignalShutdown('SIGINT');
+});

--- a/bootstrap.signal.test.ts
+++ b/bootstrap.signal.test.ts
@@ -26,7 +26,7 @@ const readUntil = async (
 
 const assertSignalShutdown = async (signal: ShutdownSignal) => {
   const child = new Deno.Command('/bin/sh', {
-    args: ['-c', `deno run -P ${FIXTURE_PATH} --signal=${signal}`],
+    args: ['-c', `exec deno run -P ${FIXTURE_PATH} --signal=${signal}`],
     stdout: 'piped',
     stderr: 'piped',
   }).spawn();

--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -1,37 +1,17 @@
 import '@std/dotenv/load';
 import { DanetApplication, Logger } from '@danet/core';
+import { installShutdownHandler } from './src/common/shutdown.ts';
 import { setup } from './src/setup.ts';
 
 const logger = new Logger('Bootstrap');
 const application = new DanetApplication();
 
-const onDispose = (tokens: number[]) => {
-  logger.log('Deno resource cleanup initiated');
-  Deno.removeSignalListener('SIGINT', onTerminationRequest);
-  Deno.removeSignalListener('SIGTERM', onTerminationRequest);
-  setTimeout(() => {
-    tokens.forEach((token) => clearTimeout(token));
-    logger.log('Deno resource cleanup completed, exiting process now!');
-    Deno.exit();
-  }, 2000);
-};
-
-const onTerminationRequest = (): void => {
-  logger.log('Deno recieved shutdown request from user or system');
-  const shutDown = setTimeout(async () => {
-    try {
-      await application.close();
-    } catch (error: Error | unknown) {
-      error instanceof Error
-        ? logger.warn(error.stack ?? error.message)
-        : logger.warn(`Unable to gracefully shutdown application: ${error}`);
-    }
-  });
-  onDispose([shutDown]);
-};
-
-Deno.addSignalListener('SIGINT', onTerminationRequest);
-Deno.addSignalListener('SIGTERM', onTerminationRequest);
+const onTerminationRequest = installShutdownHandler({
+  close: () => application.close(),
+  log: (message) => logger.log(message),
+  warn: (message) => logger.warn(message),
+  exit: () => Deno.exit(),
+});
 
 const swaggerGen = Deno.args.includes('--swagger');
 

--- a/deno.json
+++ b/deno.json
@@ -90,7 +90,8 @@
   "test": {
     "permissions": {
       "read": [".env"],
-      "env": true
+      "env": true,
+      "run": ["/bin/sh"]
     },
     "include": ["**/*.test.ts", "**/*.spec.ts", "**/testing"]
   },

--- a/src/common/shutdown.ts
+++ b/src/common/shutdown.ts
@@ -1,0 +1,63 @@
+export type SignalName = 'SIGINT' | 'SIGTERM';
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+export type ShutdownDependencies = {
+  signals?: SignalName[];
+  close: () => Promise<void>;
+  log: (message: string) => void;
+  warn: (message: string) => void;
+  exit: () => void;
+  setTimer?: typeof setTimeout;
+  clearTimer?: typeof clearTimeout;
+  addSignalListener?: typeof Deno.addSignalListener;
+  removeSignalListener?: typeof Deno.removeSignalListener;
+  cleanupDelayMs?: number;
+};
+
+export const installShutdownHandler = ({
+  signals = ['SIGINT', 'SIGTERM'],
+  close,
+  log,
+  warn,
+  exit,
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+  addSignalListener = Deno.addSignalListener,
+  removeSignalListener = Deno.removeSignalListener,
+  cleanupDelayMs = 2000,
+}: ShutdownDependencies) => {
+  const onDispose = (tokens: TimerHandle[]) => {
+    log('Deno resource cleanup initiated');
+    for (const signal of signals) {
+      removeSignalListener(signal, onTerminationRequest);
+    }
+
+    setTimer(() => {
+      tokens.forEach((token) => clearTimer(token));
+      log('Deno resource cleanup completed, exiting process now!');
+      exit();
+    }, cleanupDelayMs);
+  };
+
+  const onTerminationRequest = (): void => {
+    log('Deno recieved shutdown request from user or system');
+    const shutDown = setTimer(async () => {
+      try {
+        await close();
+      } catch (error: Error | unknown) {
+        error instanceof Error
+          ? warn(error.stack ?? error.message)
+          : warn(`Unable to gracefully shutdown application: ${error}`);
+      }
+    });
+
+    onDispose([shutDown]);
+  };
+
+  for (const signal of signals) {
+    addSignalListener(signal, onTerminationRequest);
+  }
+
+  return onTerminationRequest;
+};

--- a/tests/fixtures/signal_runtime_fixture.ts
+++ b/tests/fixtures/signal_runtime_fixture.ts
@@ -1,0 +1,32 @@
+import { installShutdownHandler } from '../../src/common/shutdown.ts';
+
+const signalArg = Deno.args.find((arg) => arg.startsWith('--signal='));
+const selectedSignal = signalArg?.split('=')[1] === 'SIGINT'
+  ? 'SIGINT'
+  : 'SIGTERM';
+
+const onTerminationRequest = installShutdownHandler({
+  close: async () => {
+    console.log('close-called');
+  },
+  log: (message) => {
+    if (message.includes('shutdown request')) {
+      console.log(`received:${selectedSignal}`);
+    }
+
+    if (message.includes('cleanup completed')) {
+      console.log('cleanup-complete');
+    }
+  },
+  warn: (message) => console.warn(message),
+  exit: () => Deno.exit(0),
+  cleanupDelayMs: 1,
+  signals: [selectedSignal],
+});
+
+console.log('fixture-ready');
+setInterval(() => {}, 1000);
+
+if (Deno.args.includes('--trigger')) {
+  onTerminationRequest();
+}


### PR DESCRIPTION
# AniTrend Pull Request

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/AniTrend/on-the-edge/blob/dev/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure you've done the following:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] You have followed our [**contributing guidelines**](https://github.com/AniTrend/on-the-edge/blob/dev/CONTRIBUTING.md)
- [x] Double checked that your branch is based on `dev` and targets `dev` (where applicable)
- [x] Pull request has tests (if applicable)
- [x] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved

## Description
Add subprocess integration coverage for bootstrap shutdown handling. The PR verifies both `SIGINT` and `SIGTERM` in real child processes, extracts the shutdown wiring into a reusable helper for deterministic testing, and keeps the timer-handle typing fix that resolves `deno task check`.

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [Apache License, Version 2.0](https://github.com/AniTrend/on-the-edge/blob/dev/LICENSE.md).