### PR TITLE
fix(workflow): enable PR auto-labeling in release-drafter v7

### DIFF
--- a/.github/workflows/release-drafter-autolabeler.yml
+++ b/.github/workflows/release-drafter-autolabeler.yml
@@ -1,0 +1,32 @@
+name: Release Drafter Autolabeler
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  autolabel-pr:
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: release-drafter/release-drafter/autolabeler@v7
+        with:
+          config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,10 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - dev
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
+      - main
 
 permissions:
   contents: read
@@ -16,8 +13,7 @@ jobs:
     permissions:
       # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      pull-requests: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v3
@@ -28,7 +24,7 @@ jobs:
       - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter-config.yml
-          commitish: ${{ github.event.repository.default_branch }}
+          commitish: main
           publish: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Description

This PR fixes PR auto-labeling by migrating release-drafter to v7 properly.

### Problem
Release-drafter v7 doesn't support mixing release drafting and PR auto-labeling in a single workflow. The previous workflow tried to run release-drafter@v7 on pull_request events, which failed because there's no valid commitish for PRs.

### Solution
- Separate concerns into two workflow files:
  - **release-drafter.yml**: triggers on push to main only, creates/updates release drafts
  - **release-drafter-autolabeler.yml**: triggers on pull_request + pull_request_target, applies labels to PRs
- Use correct v7 actions:
  - Release drafting: `release-drafter/release-drafter@v7`
  - PR labeling: `release-drafter/release-drafter/autolabeler@v7`
- Add fork-aware gating to prevent duplicate runs and handle fork PR security contexts

### Changes Made
1. Updated .github/workflows/release-drafter.yml:
   - Trigger: push to main only (removed pull_request trigger)
   - Permissions: contents:write, pull-requests:read
   - Commitish: hardcoded to main
2. Created .github/workflows/release-drafter-autolabeler.yml:
   - Triggers: pull_request + pull_request_target
   - Fork-aware conditional gate
   - Permissions: contents:read, pull-requests:write
   - Uses autolabeler@v7 action

PRs should now get auto-labeled based on branch naming conventions defined in .github/release-drafter-config.yml