### PR TITLE
feat(series): optimize locale-focused image responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,12 +23,12 @@
 ## Testing Guidelines
 - Test files match `**/*.test.ts`, `**/*.spec.ts`, and `**/testing` helpers.
 - Keep tests deterministic: use in-memory adapters and mock fetch utilities under `src/**/testing/`.
-- Aim for meaningful coverage; CI expects `deno task fmt:check`, `lint`, and `test` to pass.
+- Aim for meaningful coverage; CI mirrors `deno fmt --check`, `deno lint`, `deno task check`, `deno task test`, and `deno task build`, so the local equivalents must pass before committing.
 
 ## Commit & Pull Request Guidelines
 - Follow Conventional Commits: `feat(scope): subject`, `fix(experiment): adjust typings`.
 - Branch from `dev` using `feature/123-brief-title` or `fix/456-bug-title`; PRs should target `dev` and link issues.
-- Include tests, update docs when behavior changes, and ensure `fmt`, `lint`, and targeted tests pass locally.
+- Include tests, update docs when behavior changes, and before committing run the same quality gates enforced in `.github/workflows/ci.yml`: `bash .github/scripts/config-env.sh`, `deno fmt --check`, `deno lint`, `deno task check`, `deno task test`, and `deno task build`.
 
 ## Security & Configuration
 - Configure via `.env` (copy from `.env.example`); never commit secrets.

--- a/docs/superpowers/plans/2026-05-25-series-endpoint-image-optimization.md
+++ b/docs/superpowers/plans/2026-05-25-series-endpoint-image-optimization.md
@@ -1,0 +1,663 @@
+# Series Endpoint Image Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce the `v1/series` response payload by returning a locale-focused `images` array without changing the cached canonical `SeriesDocument`.
+
+**Architecture:** Keep `seriesTransform()` and `SeriesRepository` canonical and cache-friendly. Add a pure image-selection helper in the series package, use it in `SeriesService` after repository retrieval, and pass client locale from `SeriesController` via Danet request context.
+
+**Tech Stack:** Deno, Danet, Zod, TypeScript, std testing, Mongo-backed repository cache
+
+---
+
+## File Map
+
+- Create: `src/package/series/transformer/series.image-selection.ts`
+- Create: `src/package/series/transformer/series.image-selection.test.ts`
+- Create: `src/package/series/series.controller.test.ts`
+- Modify: `src/package/series/transformer/index.ts`
+- Modify: `src/package/series/series.service.ts`
+- Modify: `src/package/series/series.service.test.ts`
+- Modify: `src/package/series/series.controller.ts`
+
+### Task 1: Add Pure Focused Image Selection Helper
+
+**Files:**
+- Create: `src/package/series/transformer/series.image-selection.ts`
+- Create: `src/package/series/transformer/series.image-selection.test.ts`
+- Modify: `src/package/series/transformer/index.ts`
+
+- [ ] **Step 1: Write the failing helper tests**
+
+```ts
+import { describe, it } from '@std/testing/bdd';
+import { assertEquals } from '@std/assert';
+import { selectSeriesImages } from './series.image-selection.ts';
+import type { SeriesImageAttributes } from '../series.types.ts';
+
+const image = (
+  type: SeriesImageAttributes['type'],
+  locale: string | null,
+  width: number,
+  height: number,
+  url: string,
+): SeriesImageAttributes => ({
+  type,
+  locale,
+  width,
+  height,
+  url,
+});
+
+describe('selectSeriesImages', () => {
+  it('keeps the best jp and device-language image per type', () => {
+    const images: SeriesImageAttributes[] = [
+      image('POSTER', 'jp', 1000, 1500, '/poster-jp-large.jpg'),
+      image('POSTER', 'jp', 500, 750, '/poster-jp-small.jpg'),
+      image('POSTER', 'en', 800, 1200, '/poster-en.jpg'),
+      image('POSTER', 'fr', 1200, 1600, '/poster-fr.jpg'),
+      image('BACKDROP', 'jp', 1920, 1080, '/backdrop-jp.jpg'),
+      image('BACKDROP', 'en', 1280, 720, '/backdrop-en.jpg'),
+    ];
+
+    assertEquals(selectSeriesImages(images, 'en-US'), [
+      image('POSTER', 'jp', 1000, 1500, '/poster-jp-large.jpg'),
+      image('POSTER', 'en', 800, 1200, '/poster-en.jpg'),
+      image('BACKDROP', 'jp', 1920, 1080, '/backdrop-jp.jpg'),
+      image('BACKDROP', 'en', 1280, 720, '/backdrop-en.jpg'),
+    ]);
+  });
+
+  it('treats null locale as universal and does not duplicate the same image', () => {
+    const universalPoster = image('POSTER', null, 900, 1350, '/poster-null.jpg');
+
+    assertEquals(selectSeriesImages([
+      universalPoster,
+      image('POSTER', 'fr', 800, 1200, '/poster-fr.jpg'),
+    ], 'en-US'), [
+      universalPoster,
+    ]);
+  });
+
+  it('falls back to the best available image when preferred locales are missing', () => {
+    assertEquals(selectSeriesImages([
+      image('LOGO', 'fr', 300, 120, '/logo-fr-small.png'),
+      image('LOGO', 'de', 500, 200, '/logo-de-large.png'),
+    ], 'en-US'), [
+      image('LOGO', 'de', 500, 200, '/logo-de-large.png'),
+    ]);
+  });
+
+  it('uses source order as the final tie-breaker', () => {
+    assertEquals(selectSeriesImages([
+      image('POSTER', 'jp', 1000, 1500, '/poster-first.jpg'),
+      image('POSTER', 'jp', 1000, 1500, '/poster-second.jpg'),
+    ], 'en-US'), [
+      image('POSTER', 'jp', 1000, 1500, '/poster-first.jpg'),
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `deno test src/package/series/transformer/series.image-selection.test.ts`
+Expected: FAIL with `Module not found` or `selectSeriesImages is not exported`
+
+- [ ] **Step 3: Write the minimal helper implementation**
+
+```ts
+import type { SeriesImageAttributes } from '../series.types.ts';
+
+const IMAGE_TYPES: SeriesImageAttributes['type'][] = [
+  'POSTER',
+  'BACKDROP',
+  'LOGO',
+];
+
+const area = ({ width, height }: SeriesImageAttributes) => width * height;
+
+const normalizeLanguage = (locale?: string | null): string | null => {
+  if (!locale) return null;
+
+  const normalized = locale.trim().toLowerCase();
+  if (!normalized) return null;
+
+  return normalized.split(/[-_]/)[0] ?? null;
+};
+
+const rankCandidates = (
+  candidates: Array<{ image: SeriesImageAttributes; index: number; score: number }>,
+) => {
+  return candidates.toSorted((left, right) => {
+    if (right.score !== left.score) {
+      return right.score - left.score;
+    }
+
+    const areaDelta = area(right.image) - area(left.image);
+    if (areaDelta !== 0) {
+      return areaDelta;
+    }
+
+    return left.index - right.index;
+  });
+};
+
+const selectForBucket = (
+  images: SeriesImageAttributes[],
+  locale: string | null,
+  usedUrls: Set<string>,
+): SeriesImageAttributes | null => {
+  const ranked = rankCandidates(images.flatMap((image, index) => {
+    if (usedUrls.has(image.url)) {
+      return [];
+    }
+
+    const imageLocale = normalizeLanguage(image.locale);
+    if (locale && imageLocale === locale) {
+      return [{ image, index, score: 3 }];
+    }
+
+    if (image.locale === null) {
+      return [{ image, index, score: 2 }];
+    }
+
+    if (!locale) {
+      return [{ image, index, score: 1 }];
+    }
+
+    return [];
+  }));
+
+  return ranked[0]?.image ?? null;
+};
+
+export const selectSeriesImages = (
+  images: SeriesImageAttributes[],
+  locale?: string | null,
+): SeriesImageAttributes[] => {
+  const preferredLocales = Array.from(new Set([
+    'jp',
+    normalizeLanguage(locale),
+  ].filter((value): value is string => value !== null)));
+
+  const selected: SeriesImageAttributes[] = [];
+  const usedUrls = new Set<string>();
+
+  for (const type of IMAGE_TYPES) {
+    const imagesByType = images.filter((image) => image.type === type);
+    if (imagesByType.length === 0) {
+      continue;
+    }
+
+    let matchedBucket = false;
+    for (const preferredLocale of preferredLocales) {
+      const winner = selectForBucket(imagesByType, preferredLocale, usedUrls);
+      if (!winner) {
+        continue;
+      }
+
+      matchedBucket = true;
+      selected.push(winner);
+      usedUrls.add(winner.url);
+    }
+
+    if (matchedBucket) {
+      continue;
+    }
+
+    const fallback = selectForBucket(imagesByType, null, usedUrls);
+    if (fallback) {
+      selected.push(fallback);
+      usedUrls.add(fallback.url);
+    }
+  }
+
+  return selected;
+};
+```
+
+- [ ] **Step 4: Export the helper from the transformer index**
+
+```ts
+export * from './series.transformer.ts';
+export * from './series.image-selection.ts';
+```
+
+- [ ] **Step 5: Run the helper tests to verify they pass**
+
+Run: `deno test src/package/series/transformer/series.image-selection.test.ts`
+Expected: PASS with 4 passing tests
+
+- [ ] **Step 6: Commit the helper work**
+
+```bash
+git add src/package/series/transformer/series.image-selection.ts src/package/series/transformer/series.image-selection.test.ts src/package/series/transformer/index.ts
+git commit -m "feat(series): add focused image selection"
+```
+
+### Task 2: Apply Focused Image Selection In SeriesService
+
+**Files:**
+- Modify: `src/package/series/series.service.ts`
+- Modify: `src/package/series/series.service.test.ts`
+
+- [ ] **Step 1: Extend the service tests with locale-aware shaping coverage**
+
+```ts
+it('filters response images using the provided locale after repository retrieval', async () => {
+  const { logger } = createMockLogger();
+
+  const mockDocument = {
+    _id: new ObjectId(),
+    kind: 'ANIME',
+    classification: 'TV',
+    seriesKey: 'anilist:789',
+    mediaId: {
+      anidb: null,
+      anilist: 789,
+      animePlanet: null,
+      anisearch: null,
+      imdb: null,
+      kitsu: null,
+      livechart: null,
+      notify: null,
+      themoviedb: 9,
+      tvdb: 1,
+      myanimelist: 456,
+      tvMazeId: null,
+      tvrage: null,
+      slug: 'series',
+      shoboi: null,
+      trakt: 42,
+    },
+    cover: {},
+    banner: null,
+    fanart: null,
+    format: null,
+    status: null,
+    source: null,
+    title: {
+      english: null,
+      canonical: null,
+      harigana: null,
+      japanese: null,
+      romaji: null,
+      synonyms: null,
+    },
+    ageRating: null,
+    images: [
+      { type: 'POSTER', locale: 'jp', width: 1000, height: 1500, url: '/poster-jp.jpg' },
+      { type: 'POSTER', locale: 'en', width: 800, height: 1200, url: '/poster-en.jpg' },
+      { type: 'POSTER', locale: 'fr', width: 1200, height: 1600, url: '/poster-fr.jpg' },
+    ],
+    description: null,
+    updatedAt: toInstant(new Date()),
+    moreInfo: null,
+    duration: null,
+    networks: [],
+    animethemes: [],
+    trailers: [],
+    schedule: null,
+  };
+
+  const invokeSpy = spy(async () => mockDocument);
+  const repository = { invoke: invokeSpy } as unknown as SeriesRepository;
+
+  const service = new SeriesService(repository, logger);
+  const response = await service.aggregate({ anilist: 789 }, 'en-US');
+
+  assertEquals(response.images, [
+    { type: 'POSTER', locale: 'jp', width: 1000, height: 1500, url: '/poster-jp.jpg' },
+    { type: 'POSTER', locale: 'en', width: 800, height: 1200, url: '/poster-en.jpg' },
+  ]);
+  assertEquals(mockDocument.images.length, 3);
+});
+
+it('falls back to jp and universal images when locale is missing', async () => {
+  const { logger } = createMockLogger();
+
+  const mockDocument = {
+    _id: new ObjectId(),
+    kind: 'ANIME',
+    classification: 'TV',
+    seriesKey: 'anilist:789',
+    mediaId: {
+      anidb: null,
+      anilist: 789,
+      animePlanet: null,
+      anisearch: null,
+      imdb: null,
+      kitsu: null,
+      livechart: null,
+      notify: null,
+      themoviedb: 9,
+      tvdb: 1,
+      myanimelist: 456,
+      tvMazeId: null,
+      tvrage: null,
+      slug: 'series',
+      shoboi: null,
+      trakt: 42,
+    },
+    cover: {},
+    banner: null,
+    fanart: null,
+    format: null,
+    status: null,
+    source: null,
+    title: {
+      english: null,
+      canonical: null,
+      harigana: null,
+      japanese: null,
+      romaji: null,
+      synonyms: null,
+    },
+    ageRating: null,
+    images: [
+      { type: 'LOGO', locale: null, width: 500, height: 200, url: '/logo-null.png' },
+      { type: 'LOGO', locale: 'fr', width: 300, height: 120, url: '/logo-fr.png' },
+    ],
+    description: null,
+    updatedAt: toInstant(new Date()),
+    moreInfo: null,
+    duration: null,
+    networks: [],
+    animethemes: [],
+    trailers: [],
+    schedule: null,
+  };
+
+  const repository = {
+    invoke: spy(async () => mockDocument),
+  } as unknown as SeriesRepository;
+
+  const service = new SeriesService(repository, logger);
+  const response = await service.aggregate({ anilist: 789 });
+
+  assertEquals(response.images, [
+    { type: 'LOGO', locale: null, width: 500, height: 200, url: '/logo-null.png' },
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the service test file to verify the new cases fail**
+
+Run: `deno test src/package/series/series.service.test.ts`
+Expected: FAIL because `SeriesService.aggregate()` does not yet accept locale or reshape `images`
+
+- [ ] **Step 3: Update the service to reshape images at the response boundary**
+
+```ts
+import { Injectable, InternalServerErrorException } from '@danet/core';
+import { BadRequestException } from '@danet/core';
+import { LoggerService } from '@scope/logger';
+import { SeriesRepository } from './repository/index.ts';
+import { selectSeriesImages } from './transformer/index.ts';
+import type { Series } from './series.types.ts';
+import type { SeriesQuery } from './series.types.ts';
+
+@Injectable()
+export class SeriesService {
+  constructor(
+    private readonly repository: SeriesRepository,
+    private readonly logger: LoggerService,
+  ) {}
+
+  async aggregate(query: SeriesQuery, locale?: string): Promise<Series> {
+    if (!query || Object.keys(query).length === 0) {
+      this.logger.instance.warn('Provided empty query to aggregate series');
+      throw new BadRequestException();
+    }
+
+    if (!query.anilist) {
+      this.logger.instance.warn('AniList ID required for repository lookup', {
+        query,
+      });
+      throw new BadRequestException();
+    }
+
+    try {
+      const { _id, images, ...entity } = await this.repository.invoke(query);
+      return {
+        id: _id.toHexString(),
+        ...entity,
+        images: selectSeriesImages(images, locale),
+      } satisfies Series;
+    } catch (error) {
+      this.logger.instance.error('Failed to aggregate series', {
+        query,
+        cause: error,
+      });
+      throw new InternalServerErrorException();
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the service tests to verify they pass**
+
+Run: `deno test src/package/series/series.service.test.ts`
+Expected: PASS with the existing validation tests plus the new locale-shaping cases
+
+- [ ] **Step 5: Commit the service integration**
+
+```bash
+git add src/package/series/series.service.ts src/package/series/series.service.test.ts
+git commit -m "feat(series): filter response images by locale"
+```
+
+### Task 3: Pass Client Locale From SeriesController
+
+**Files:**
+- Create: `src/package/series/series.controller.test.ts`
+- Modify: `src/package/series/series.controller.ts`
+
+- [ ] **Step 1: Write a controller test for locale extraction and delegation**
+
+```ts
+import { describe, it } from '@std/testing/bdd';
+import { assertEquals } from '@std/assert';
+import { spy } from '@std/testing/mock';
+import type { ExecutionContext } from '@danet/core';
+import { createMockLogger } from '@scope/common/testing';
+import { SeriesController } from './series.controller.ts';
+import type { SeriesService } from './series.service.ts';
+
+describe('SeriesController', () => {
+  it('passes the client locale from request context into the service', async () => {
+    const aggregate = spy(async () => ({
+      id: '507f1f77bcf86cd799439011',
+      kind: 'ANIME',
+      classification: null,
+      mediaId: {
+        anidb: null,
+        anilist: 789,
+        animePlanet: null,
+        anisearch: null,
+        imdb: null,
+        kitsu: null,
+        livechart: null,
+        notify: null,
+        themoviedb: null,
+        tvdb: null,
+        myanimelist: null,
+        tvMazeId: null,
+        tvrage: null,
+        slug: null,
+        shoboi: null,
+        trakt: null,
+      },
+      cover: {},
+      banner: null,
+      fanart: null,
+      format: null,
+      status: null,
+      source: null,
+      title: {
+        english: null,
+        canonical: null,
+        harigana: null,
+        japanese: null,
+        romaji: null,
+        synonyms: null,
+      },
+      ageRating: null,
+      images: [],
+      description: null,
+      updatedAt: Date.now(),
+      moreInfo: null,
+      animethemes: [],
+      schedule: null,
+      trailers: [],
+      networks: [],
+      airedEpisodes: null,
+      broadcast: null,
+      isAdult: null,
+      homepage: null,
+      duration: null,
+      chapters: null,
+      volumes: null,
+      publishedFrom: null,
+      publishedTo: null,
+    }));
+
+    const { logger } = createMockLogger();
+    const controller = new SeriesController(
+      { aggregate } as unknown as SeriesService,
+      logger,
+    );
+
+    const context = {
+      get: (key: string) => {
+        if (key === 'client-attributes') {
+          return {
+            locale: 'en-US',
+            version: '1.0.0',
+            source: 'android',
+            code: 'app',
+            label: 'AniTrend',
+            build: '1',
+            platform: {
+              browserName: null,
+              browserVersion: null,
+              cpuArchitecture: null,
+              deviceModel: null,
+              deviceVendor: null,
+              deviceType: null,
+              engineName: null,
+              engineVersion: null,
+              osName: null,
+              osVersion: null,
+            },
+          };
+        }
+
+        return undefined;
+      },
+    } as unknown as ExecutionContext;
+
+    await controller.series({ anilist: 789 }, context);
+
+    assertEquals(aggregate.calls[0]?.args, [{ anilist: 789 }, 'en-US']);
+  });
+});
+```
+
+- [ ] **Step 2: Run the controller test to verify it fails**
+
+Run: `deno test src/package/series/series.controller.test.ts`
+Expected: FAIL because the controller does not yet accept `@Context()` or pass locale to the service
+
+- [ ] **Step 3: Update the controller to read client attributes and pass locale**
+
+```ts
+import {
+  Context,
+  Controller,
+  type ExecutionContext,
+  Get,
+} from '@danet/core';
+import { Query } from '@danet/zod';
+import { ReturnedSchema } from '@danet/zod';
+import { getClientAttributes } from '@scope/common/utils';
+import { LoggerService } from '@scope/logger';
+import { SeriesService } from './series.service.ts';
+import { SeriesQuerySchema } from './series.schema.ts';
+import type { MediaUnion, SeriesQuery } from './series.types.ts';
+import { SeriesSwagger } from './series.swagger.ts';
+
+@Controller('v1')
+export class SeriesController {
+  constructor(
+    private readonly service: SeriesService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  @Get('series')
+  @ReturnedSchema(SeriesSwagger)
+  async series(
+    @Query(SeriesQuerySchema) query: SeriesQuery,
+    @Context() context: ExecutionContext,
+  ): Promise<MediaUnion> {
+    const client = getClientAttributes(context as never);
+    return await this.service.aggregate(query, client?.locale);
+  }
+}
+```
+
+- [ ] **Step 4: Run the controller and service tests together**
+
+Run: `deno test src/package/series/series.controller.test.ts src/package/series/series.service.test.ts`
+Expected: PASS with locale delegation and service shaping verified
+
+- [ ] **Step 5: Commit the controller wiring**
+
+```bash
+git add src/package/series/series.controller.ts src/package/series/series.controller.test.ts
+git commit -m "feat(series): pass request locale to service"
+```
+
+### Task 4: Final Verification And Cleanup
+
+**Files:**
+- Modify: `src/package/series/series.service.ts`
+- Modify: `src/package/series/series.controller.ts`
+- Modify: `src/package/series/transformer/series.image-selection.ts`
+- Modify: `src/package/series/transformer/series.image-selection.test.ts`
+- Modify: `src/package/series/series.service.test.ts`
+- Modify: `src/package/series/series.controller.test.ts`
+
+- [ ] **Step 1: Format the changed files**
+
+Run: `deno fmt src/package/series/series.controller.ts src/package/series/series.controller.test.ts src/package/series/series.service.ts src/package/series/series.service.test.ts src/package/series/transformer/series.image-selection.ts src/package/series/transformer/series.image-selection.test.ts src/package/series/transformer/index.ts`
+Expected: PASS with no formatting errors
+
+- [ ] **Step 2: Run the focused series tests**
+
+Run: `deno test src/package/series/series.controller.test.ts src/package/series/series.service.test.ts src/package/series/transformer/series.image-selection.test.ts src/package/series/transformer/series.anime.transformer.test.ts src/package/series/transformer/series.manga.transformer.test.ts`
+Expected: PASS with all series-facing response shaping and transformer coverage green
+
+- [ ] **Step 3: Run lint and type checks**
+
+Run: `deno task lint && deno task check`
+Expected: PASS with no lint or type errors
+
+- [ ] **Step 4: Inspect the final diff before the last commit**
+
+Run: `git diff --stat && git diff -- src/package/series/series.controller.ts src/package/series/series.service.ts src/package/series/transformer/series.image-selection.ts src/package/series/series.controller.test.ts src/package/series/series.service.test.ts src/package/series/transformer/series.image-selection.test.ts src/package/series/transformer/index.ts`
+Expected: Only the locale-aware response-shaping files and tests are changed
+
+- [ ] **Step 5: Commit any verification-driven fixes**
+
+```bash
+git add src/package/series/series.controller.ts src/package/series/series.controller.test.ts src/package/series/series.service.ts src/package/series/series.service.test.ts src/package/series/transformer/series.image-selection.ts src/package/series/transformer/series.image-selection.test.ts src/package/series/transformer/index.ts
+git commit -m "test(series): verify focused image response shaping"
+```
+
+## Self-Review Checklist
+
+- Spec coverage: helper selection, service boundary shaping, controller locale access, and verification are all mapped to tasks.
+- Placeholder scan: no `TODO`, `TBD`, or “implement later” language remains.
+- Type consistency: `selectSeriesImages(images, locale)` and `SeriesService.aggregate(query, locale)` are used consistently across all tasks.

--- a/docs/superpowers/specs/2026-05-25-series-endpoint-image-optimization-design.md
+++ b/docs/superpowers/specs/2026-05-25-series-endpoint-image-optimization-design.md
@@ -1,0 +1,210 @@
+# Series Endpoint Image Optimization Design
+
+## Goal
+
+Reduce the `v1/series` response payload by returning a focused `images`
+array that keeps only the most relevant images for Japanese and the client
+device language, without changing the cached canonical series document.
+
+## Current State
+
+- `HeaderMiddleware` already requires `x-app-locale` and stores it in client
+  attributes for each request.
+- `SeriesController` currently passes only query params into `SeriesService`.
+- `SeriesService` delegates to `SeriesRepository`, then returns the cached
+  `SeriesDocument` as the API response shape.
+- `seriesTransform()` currently maps every TMDB image into the response
+  `images` array, which can produce a much larger payload than clients need.
+- The repository cache is intentionally reusable across requests, so it should
+  continue storing the full upstream image set.
+
+## Design Summary
+
+The optimization will happen only at the response boundary.
+
+- Keep the repository and persisted `SeriesDocument` unchanged.
+- Read the client locale from the current request context.
+- Pass the locale into `SeriesService.aggregate()`.
+- Filter the response `images` array after repository retrieval and before the
+  response is returned to the client.
+- Preserve the existing response schema: `images` remains
+  `SeriesImageAttributes[]`.
+
+This keeps caching reusable while making the API response locale-aware.
+
+## Locale Rules
+
+### Primary Locales
+
+The response should prefer two locale buckets:
+
+1. `jp`
+2. The client device language derived from `x-app-locale`
+
+Locale derivation is language-first:
+
+- `en-US` becomes `en`
+- `pt-BR` becomes `pt`
+- `ja-JP` becomes `ja`
+
+If the derived device language resolves to the same effective bucket already in
+use, the response must not duplicate that bucket.
+
+### Universal Images
+
+TMDB images with `locale === null` are treated as universally acceptable.
+These can satisfy either preferred bucket when no explicit locale match exists.
+
+## Image Selection Rules
+
+### Output Shape
+
+The endpoint should return a reduced `images` array with, at most, one selected
+image per preferred bucket and image type.
+
+Image types remain:
+
+- `POSTER`
+- `BACKDROP`
+- `LOGO`
+
+For each image type, the response attempts to select:
+
+1. The best `jp` image
+2. The best device-language image
+
+This means a type can contribute:
+
+- two images when both preferred locale buckets are available
+- one image when only one preferred bucket or a universal fallback is available
+- zero images when no source images exist for that type
+
+### Bucket Fallback Order
+
+For each image type and preferred bucket, selection should follow this order:
+
+1. Exact preferred locale bucket match
+2. `locale === null`
+3. Best remaining image regardless of locale, but only when neither preferred
+   bucket can be satisfied by a locale-specific or universal image
+
+This preserves enrichment while ensuring a type is still represented when TMDB
+does not provide the preferred locales.
+
+### Best Image Ranking
+
+When more than one candidate can satisfy a bucket, rank candidates in this
+order:
+
+1. Locale-specific match beats universal (`null`) fallback
+2. Universal (`null`) fallback beats unrelated locale fallback
+3. Larger image area (`width * height`) beats smaller image area
+4. Original source order is the final tie-breaker
+
+This ranking keeps behavior deterministic and simple to test.
+
+### Deduplication
+
+The same image must not appear twice in the final `images` array.
+
+Deduplication matters when:
+
+- the device language bucket is already the same effective value as another
+  preferred bucket
+- a universal image satisfies the first bucket and would otherwise be selected
+  again for the second bucket
+- a best-available fallback candidate would duplicate an already chosen image
+
+## Integration Plan
+
+### Controller
+
+`SeriesController` will gain access to request client attributes so it can pass
+the locale to the service layer.
+
+Responsibilities:
+
+- read the current client locale from request context
+- call `SeriesService.aggregate(query, locale)` or an equivalent locale-aware
+  service signature
+
+### Service
+
+`SeriesService` will remain the response boundary for this optimization.
+
+Responsibilities:
+
+- keep query validation unchanged
+- call `SeriesRepository.invoke(query)` unchanged
+- apply focused image filtering to the returned entity before sending the
+  response back to the controller
+
+The service should only reshape the returned `images` field. No repository or
+cache behavior changes are required.
+
+### Selection Helper
+
+Add a small focused helper inside the series package to keep the locale-aware
+selection logic isolated and unit-testable.
+
+Responsibilities:
+
+- normalize the client locale into a language bucket
+- group images by `type`
+- select winners for `jp` and the device language buckets
+- apply universal and best-available fallback rules
+- deduplicate selected images while preserving deterministic output ordering
+
+This helper should be pure and independent of Mongo or upstream services.
+
+## Error Handling And Failure Behavior
+
+- If request locale is unexpectedly missing, the response should still prefer
+  `jp`, then universal images, then best available images.
+- If a series has no images, the endpoint continues returning an empty `images`
+  array.
+- If a specific image type has no candidates, that type is simply absent from
+  the reduced `images` array.
+- No schema migration or cache invalidation is required.
+
+## Testing Strategy
+
+Add focused unit coverage for the selection helper and service integration.
+
+### Helper Tests
+
+Cover:
+
+- locale normalization from values such as `en-US`
+- `jp` plus device-language selection when both exist
+- `null` locale acting as a universal fallback
+- best-available fallback when neither preferred locale exists
+- deduplication when a universal image could satisfy multiple buckets
+- deterministic ranking by image size and source order
+- no cross-type interference between `POSTER`, `BACKDROP`, and `LOGO`
+
+### Service Or Controller Tests
+
+Cover:
+
+- locale-aware shaping happening after repository retrieval
+- full repository document remaining unchanged before response shaping
+- response schema staying identical except for the reduced image count
+
+## Out Of Scope
+
+- changing the MongoDB cache shape
+- changing upstream TMDB fetch behavior
+- introducing new API fields or versioned response contracts
+- altering other series payload enrichment fields
+
+## Acceptance Criteria
+
+- `v1/series` returns a smaller `images` array focused on `jp` and the client
+  device language.
+- `x-app-locale` is interpreted language-first for the secondary bucket.
+- `locale === null` images are treated as universal fallbacks.
+- Best-available images are returned when preferred locales do not exist.
+- Persisted cached series documents remain unchanged and reusable for later
+  requests.
+- The response schema remains backward-compatible.

--- a/src/package/series/repository/index.ts
+++ b/src/package/series/repository/index.ts
@@ -1,1 +1,2 @@
 export { SeriesRepository } from './series.repository.ts';
+export { SeriesNotFoundError } from './series.errors.ts';

--- a/src/package/series/repository/index.ts
+++ b/src/package/series/repository/index.ts
@@ -1,2 +1,2 @@
 export { SeriesRepository } from './series.repository.ts';
-export { SeriesNotFoundError } from './series.errors.ts';
+export { SeriesArmLookupError, SeriesNotFoundError } from './series.errors.ts';

--- a/src/package/series/repository/series.errors.ts
+++ b/src/package/series/repository/series.errors.ts
@@ -4,3 +4,11 @@ export class SeriesNotFoundError extends Error {
     this.name = 'SeriesNotFoundError';
   }
 }
+
+export class SeriesArmLookupError extends Error {
+  constructor(cause: unknown) {
+    super('Failed to resolve series relation from ARM');
+    this.name = 'SeriesArmLookupError';
+    this.cause = cause;
+  }
+}

--- a/src/package/series/repository/series.errors.ts
+++ b/src/package/series/repository/series.errors.ts
@@ -1,0 +1,6 @@
+export class SeriesNotFoundError extends Error {
+  constructor() {
+    super('Series not found');
+    this.name = 'SeriesNotFoundError';
+  }
+}

--- a/src/package/series/repository/series.resolver.test.ts
+++ b/src/package/series/repository/series.resolver.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from '@std/testing/bdd';
 import { assertEquals, assertRejects } from '@std/assert';
 import { assertSpyCalls, spy } from '@std/testing/mock';
 import { SeriesResolver } from './series.resolver.ts';
-import { SeriesNotFoundError } from './index.ts';
+import { SeriesArmLookupError, SeriesNotFoundError } from './index.ts';
 import { createMockExperiment, createMockLogger } from '@scope/common/testing';
 import type {
   AnimeThemesLookupModel,
@@ -194,6 +194,41 @@ describe('SeriesResolver', () => {
     await assertRejects(
       () => resolver.resolve({ anilist: 400 }),
       SeriesNotFoundError,
+    );
+  });
+
+  it('throws SeriesArmLookupError when ARM lookup fails upstream', async () => {
+    const { logger } = createMockLogger();
+    const experiment = createMockExperiment({
+      'enable-animethemes-api': false,
+    });
+    const upstreamError = new Error('ARM timeout');
+
+    const resolver = new SeriesResolver(
+      { getShow: async () => undefined } as unknown as TraktService,
+      {
+        getShow: async () => undefined,
+        getMovie: async () => undefined,
+      } as unknown as TmdbService,
+      { getShowByTvdb: async () => undefined } as unknown as SkyhookService,
+      { getAnime: async () => undefined } as unknown as NotifyService,
+      { getAnime: async () => undefined } as unknown as JikanService,
+      {
+        getRelationsById: async () => {
+          throw upstreamError;
+        },
+      } as unknown as ArmService,
+      { getMappingsByTvdb: async () => undefined } as unknown as TheXemService,
+      {
+        getThemesForAnime: async () => undefined,
+      } as unknown as AnimeThemesService,
+      experiment,
+      logger,
+    );
+
+    await assertRejects(
+      () => resolver.resolve({ anilist: 400 }),
+      SeriesArmLookupError,
     );
   });
 });

--- a/src/package/series/repository/series.resolver.test.ts
+++ b/src/package/series/repository/series.resolver.test.ts
@@ -1,7 +1,8 @@
 import { describe, it } from '@std/testing/bdd';
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertRejects } from '@std/assert';
 import { assertSpyCalls, spy } from '@std/testing/mock';
 import { SeriesResolver } from './series.resolver.ts';
+import { SeriesNotFoundError } from './index.ts';
 import { createMockExperiment, createMockLogger } from '@scope/common/testing';
 import type {
   AnimeThemesLookupModel,
@@ -163,6 +164,36 @@ describe('SeriesResolver', () => {
     assertEquals(
       'animethemes' in result ? result.animethemes : [],
       animeThemesLookup.anime[0].animethemes,
+    );
+  });
+
+  it('throws SeriesNotFoundError when no relation can be resolved', async () => {
+    const { logger } = createMockLogger();
+    const experiment = createMockExperiment({
+      'enable-animethemes-api': false,
+    });
+
+    const resolver = new SeriesResolver(
+      { getShow: async () => undefined } as unknown as TraktService,
+      {
+        getShow: async () => undefined,
+        getMovie: async () => undefined,
+      } as unknown as TmdbService,
+      { getShowByTvdb: async () => undefined } as unknown as SkyhookService,
+      { getAnime: async () => undefined } as unknown as NotifyService,
+      { getAnime: async () => undefined } as unknown as JikanService,
+      { getRelationsById: async () => undefined } as unknown as ArmService,
+      { getMappingsByTvdb: async () => undefined } as unknown as TheXemService,
+      {
+        getThemesForAnime: async () => undefined,
+      } as unknown as AnimeThemesService,
+      experiment,
+      logger,
+    );
+
+    await assertRejects(
+      () => resolver.resolve({ anilist: 400 }),
+      SeriesNotFoundError,
     );
   });
 });

--- a/src/package/series/repository/series.resolver.ts
+++ b/src/package/series/repository/series.resolver.ts
@@ -12,6 +12,7 @@ import { Injectable } from '@danet/core';
 import { MediaUnion, SeriesQuery } from '../series.types.ts';
 import { isAnime } from './helpers/qualifier.ts';
 import { seriesTransform } from '../transformer/series.transformer.ts';
+import { SeriesNotFoundError } from './series.errors.ts';
 
 @Injectable()
 export class SeriesResolver {
@@ -188,7 +189,7 @@ export class SeriesResolver {
     const relation = await this.resolveArm(param);
 
     if (!relation) {
-      throw new Error('Series not found');
+      throw new SeriesNotFoundError();
     }
 
     // Fetch Notify and Jikan in parallel as they are independent

--- a/src/package/series/repository/series.resolver.ts
+++ b/src/package/series/repository/series.resolver.ts
@@ -12,7 +12,7 @@ import { Injectable } from '@danet/core';
 import { MediaUnion, SeriesQuery } from '../series.types.ts';
 import { isAnime } from './helpers/qualifier.ts';
 import { seriesTransform } from '../transformer/series.transformer.ts';
-import { SeriesNotFoundError } from './series.errors.ts';
+import { SeriesArmLookupError, SeriesNotFoundError } from './series.errors.ts';
 
 @Injectable()
 export class SeriesResolver {
@@ -124,20 +124,27 @@ export class SeriesResolver {
     query: SeriesQuery,
   ): Promise<SeriesRelationId | undefined> => {
     const { anilist, mal } = query;
+    if (!anilist && !mal) {
+      throw new Error('No valid identifier provided for ARM lookup');
+    }
+
     try {
       if (anilist) {
         return await this.arm.getRelationsById('anilist', anilist);
-      } else if (mal) {
+      }
+
+      if (mal) {
         return await this.arm.getRelationsById('myanimelist', mal);
       }
-      throw new Error('No valid identifier provided for ARM lookup');
     } catch (error) {
       this.logger.instance.warn('Failed to fetch Arm anime', {
         query,
         error,
       });
-      return undefined;
+      throw new SeriesArmLookupError(error);
     }
+
+    return undefined;
   };
 
   private resolveTheXem = async (

--- a/src/package/series/series.controller.test.ts
+++ b/src/package/series/series.controller.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from '@std/testing/bdd';
+import { assertSpyCall } from '@std/testing/mock';
+import { spy } from '@std/testing/mock';
+import { SeriesController } from './series.controller.ts';
+import { SeriesService } from './series.service.ts';
+import { createMockLogger } from '@scope/common/testing';
+
+describe('SeriesController', () => {
+  it('passes the client locale from request context into the service', async () => {
+    const { logger } = createMockLogger();
+    const aggregateSpy = spy(async () => ({}) as never);
+    const service = { aggregate: aggregateSpy } as unknown as SeriesService;
+    const controller = new SeriesController(service, logger);
+
+    const query = { anilist: 789 };
+    const context = {
+      get: (key: string) => {
+        if (key === 'client-attributes') {
+          return {
+            locale: 'en-US',
+          };
+        }
+
+        return undefined;
+      },
+    };
+
+    await (controller.series as (...args: unknown[]) => Promise<unknown>)(
+      query,
+      context,
+    );
+
+    assertSpyCall(aggregateSpy, 0, {
+      args: [query, 'en-US'],
+    });
+  });
+
+  it('calls the service with undefined locale when client attributes are missing', async () => {
+    const { logger } = createMockLogger();
+    const aggregateSpy = spy(async () => ({}) as never);
+    const service = { aggregate: aggregateSpy } as unknown as SeriesService;
+    const controller = new SeriesController(service, logger);
+
+    const query = { anilist: 789 };
+    const context = {
+      get: () => undefined,
+    };
+
+    await (controller.series as (...args: unknown[]) => Promise<unknown>)(
+      query,
+      context,
+    );
+
+    assertSpyCall(aggregateSpy, 0, {
+      args: [query, undefined],
+    });
+  });
+});

--- a/src/package/series/series.controller.ts
+++ b/src/package/series/series.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get } from '@danet/core';
+import { Context, Controller, type ExecutionContext, Get } from '@danet/core';
 import { Query } from '@danet/zod';
 import { ReturnedSchema } from '@danet/zod';
+import { getClientAttributes } from '@scope/common/utils';
 import { LoggerService } from '@scope/logger';
 import { SeriesService } from './series.service.ts';
 import { SeriesQuerySchema } from './series.schema.ts';
@@ -18,7 +19,9 @@ export class SeriesController {
   @ReturnedSchema(SeriesSwagger)
   async series(
     @Query(SeriesQuerySchema) query: SeriesQuery,
+    @Context() context: ExecutionContext,
   ): Promise<MediaUnion> {
-    return await this.service.aggregate(query);
+    const locale = getClientAttributes(context)?.locale;
+    return await this.service.aggregate(query, locale);
   }
 }

--- a/src/package/series/series.service.test.ts
+++ b/src/package/series/series.service.test.ts
@@ -1,12 +1,69 @@
 import { describe, it } from '@std/testing/bdd';
 import { assertEquals, assertRejects } from '@std/assert';
 import { assertSpyCall, spy } from '@std/testing/mock';
-import { BadRequestException, InternalServerErrorException } from '@danet/core';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@danet/core';
 import { ObjectId } from 'mongodb';
 import { SeriesService } from './series.service.ts';
 import { SeriesRepository } from './repository/index.ts';
+import { SeriesNotFoundError } from './repository/index.ts';
 import { createMockLogger } from '@scope/common/testing';
 import { toInstant } from '@scope/common/utils';
+
+const createSeriesDocument = (
+  overrides: Partial<Record<string, unknown>> = {},
+) => ({
+  _id: new ObjectId(),
+  kind: 'ANIME',
+  classification: 'TV',
+  seriesKey: 'anilist:789',
+  mediaId: {
+    anidb: null,
+    anilist: 789,
+    animePlanet: null,
+    anisearch: null,
+    imdb: 'tt123',
+    kitsu: null,
+    livechart: null,
+    notify: 'notify-1',
+    themoviedb: 9,
+    tvdb: 1,
+    myanimelist: 456,
+    tvMazeId: null,
+    tvrage: null,
+    slug: 'series',
+    shoboi: null,
+    trakt: 42,
+  },
+  cover: {},
+  banner: null,
+  fanart: null,
+  format: null,
+  status: null,
+  source: null,
+  title: {
+    english: null,
+    canonical: null,
+    harigana: null,
+    japanese: null,
+    romaji: null,
+    synonyms: null,
+  },
+  ageRating: null,
+  images: [],
+  description: null,
+  updatedAt: toInstant(new Date()),
+  moreInfo: null,
+  duration: null,
+  networks: [],
+  animethemes: [],
+  trailers: [],
+  schedule: null,
+  ...overrides,
+});
 
 describe('SeriesService', () => {
   it('throws BadRequestException when query is empty', async () => {
@@ -34,54 +91,7 @@ describe('SeriesService', () => {
   it('delegates to repository.invoke() with anilist ID', async () => {
     const { logger } = createMockLogger();
 
-    const mockDocument = {
-      _id: new ObjectId(),
-      kind: 'ANIME',
-      classification: 'TV',
-      seriesKey: 'anilist:789',
-      mediaId: {
-        anidb: null,
-        anilist: 789,
-        animePlanet: null,
-        anisearch: null,
-        imdb: 'tt123',
-        kitsu: null,
-        livechart: null,
-        notify: 'notify-1',
-        themoviedb: 9,
-        tvdb: 1,
-        myanimelist: 456,
-        tvMazeId: null,
-        tvrage: null,
-        slug: 'series',
-        shoboi: null,
-        trakt: 42,
-      },
-      cover: {},
-      banner: null,
-      fanart: null,
-      format: null,
-      status: null,
-      source: null,
-      title: {
-        english: null,
-        canonical: null,
-        harigana: null,
-        japanese: null,
-        romaji: null,
-        synonyms: null,
-      },
-      ageRating: null,
-      images: [],
-      description: null,
-      updatedAt: toInstant(new Date()),
-      moreInfo: null,
-      duration: null,
-      networks: [],
-      animethemes: [],
-      trailers: [],
-      schedule: null,
-    };
+    const mockDocument = createSeriesDocument();
 
     const invokeSpy = spy(async () => mockDocument);
     const repository = { invoke: invokeSpy } as unknown as SeriesRepository;
@@ -106,12 +116,130 @@ describe('SeriesService', () => {
     assertEquals(response.mediaId.myanimelist, 456);
   });
 
-  it('throws NotFoundException when repository throws "No data available"', async () => {
-    const { logger, spies } = createMockLogger();
+  it('filters response images using the provided locale after repository retrieval', async () => {
+    const { logger } = createMockLogger();
 
-    const expectedError = new Error(
-      'No data available from any upstream service',
-    );
+    const mockDocument = createSeriesDocument({
+      images: [
+        {
+          type: 'POSTER',
+          locale: 'jp',
+          url: 'poster-jp',
+          width: 1000,
+          height: 1500,
+        },
+        {
+          type: 'POSTER',
+          locale: 'en',
+          url: 'poster-en',
+          width: 900,
+          height: 1350,
+        },
+        {
+          type: 'BACKDROP',
+          locale: 'jp',
+          url: 'backdrop-jp',
+          width: 1920,
+          height: 1080,
+        },
+        {
+          type: 'BACKDROP',
+          locale: 'en',
+          url: 'backdrop-en',
+          width: 1920,
+          height: 1080,
+        },
+      ],
+    });
+    const invokeSpy = spy(async () => mockDocument);
+    const repository = { invoke: invokeSpy } as unknown as SeriesRepository;
+
+    const service = new SeriesService(repository, logger);
+    const response = await service.aggregate({ anilist: 789 }, 'en-US');
+
+    assertEquals(response.images.map(({ url }) => url), [
+      'poster-jp',
+      'poster-en',
+      'backdrop-jp',
+      'backdrop-en',
+    ]);
+  });
+
+  it('does not mutate repository-returned document images when filtering the response', async () => {
+    const { logger } = createMockLogger();
+
+    const mockDocument = createSeriesDocument({
+      images: [
+        {
+          type: 'POSTER',
+          locale: 'jp',
+          url: 'poster-jp',
+          width: 1000,
+          height: 1500,
+        },
+        {
+          type: 'POSTER',
+          locale: null,
+          url: 'poster-universal',
+          width: 1000,
+          height: 1500,
+        },
+      ],
+    });
+    const originalImages = structuredClone(mockDocument.images);
+    const invokeSpy = spy(async () => mockDocument);
+    const repository = { invoke: invokeSpy } as unknown as SeriesRepository;
+
+    const service = new SeriesService(repository, logger);
+    await service.aggregate({ anilist: 789 }, 'en-US');
+
+    assertEquals(mockDocument.images, originalImages);
+  });
+
+  it('falls back to jp and then the best available images when locale is missing', async () => {
+    const { logger } = createMockLogger();
+
+    const mockDocument = createSeriesDocument({
+      images: [
+        {
+          type: 'POSTER',
+          locale: 'jp',
+          url: 'poster-jp',
+          width: 1000,
+          height: 1500,
+        },
+        {
+          type: 'POSTER',
+          locale: 'fr',
+          url: 'poster-fr-large',
+          width: 1200,
+          height: 1800,
+        },
+        {
+          type: 'POSTER',
+          locale: 'es',
+          url: 'poster-es-small',
+          width: 800,
+          height: 1200,
+        },
+      ],
+    });
+    const invokeSpy = spy(async () => mockDocument);
+    const repository = { invoke: invokeSpy } as unknown as SeriesRepository;
+
+    const service = new SeriesService(repository, logger);
+    const response = await service.aggregate({ anilist: 789 });
+
+    assertEquals(response.images.map(({ url }) => url), [
+      'poster-jp',
+      'poster-fr-large',
+    ]);
+  });
+
+  it('throws NotFoundException when repository throws "No data available"', async () => {
+    const { logger } = createMockLogger();
+
+    const expectedError = new SeriesNotFoundError();
     const invokeSpy = spy(async () => {
       throw expectedError;
     });
@@ -121,19 +249,11 @@ describe('SeriesService', () => {
 
     await assertRejects(
       () => service.aggregate({ anilist: 789 }),
-      InternalServerErrorException,
+      NotFoundException,
     );
-
-    // Assert logger.error was called with query and the exception
-    assertSpyCall(spies.error, 0, {
-      args: [
-        'Failed to aggregate series',
-        { query: { anilist: 789 }, cause: expectedError },
-      ],
-    });
   });
 
-  it('propagates other errors from repository', async () => {
+  it('wraps unexpected repository errors in InternalServerErrorException', async () => {
     const { logger, spies } = createMockLogger();
 
     const customError = new Error('Database connection failed');
@@ -146,7 +266,7 @@ describe('SeriesService', () => {
 
     await assertRejects(
       () => service.aggregate({ anilist: 789 }),
-      Error,
+      InternalServerErrorException,
       '500 - Internal server error',
     );
 

--- a/src/package/series/series.service.test.ts
+++ b/src/package/series/series.service.test.ts
@@ -9,7 +9,10 @@ import {
 import { ObjectId } from 'mongodb';
 import { SeriesService } from './series.service.ts';
 import { SeriesRepository } from './repository/index.ts';
-import { SeriesNotFoundError } from './repository/index.ts';
+import {
+  SeriesArmLookupError,
+  SeriesNotFoundError,
+} from './repository/index.ts';
 import { createMockLogger } from '@scope/common/testing';
 import { toInstant } from '@scope/common/utils';
 
@@ -165,6 +168,88 @@ describe('SeriesService', () => {
     ]);
   });
 
+  it('prefers the device locale before universal fallback when jp is unavailable', async () => {
+    const { logger } = createMockLogger();
+
+    const mockDocument = createSeriesDocument({
+      images: [
+        {
+          type: 'POSTER',
+          locale: null,
+          url: 'poster-universal',
+          width: 1000,
+          height: 1500,
+        },
+        {
+          type: 'POSTER',
+          locale: 'en',
+          url: 'poster-en',
+          width: 900,
+          height: 1350,
+        },
+        {
+          type: 'POSTER',
+          locale: 'fr',
+          url: 'poster-fr',
+          width: 1200,
+          height: 1800,
+        },
+      ],
+    });
+    const repository = {
+      invoke: spy(async () => mockDocument),
+    } as unknown as SeriesRepository;
+
+    const service = new SeriesService(repository, logger);
+    const response = await service.aggregate({ anilist: 789 }, 'en-US');
+
+    assertEquals(response.images.map(({ url }) => url), [
+      'poster-en',
+      'poster-universal',
+    ]);
+  });
+
+  it('does not return unrelated locale images after universal fallback for locale-specific requests', async () => {
+    const { logger } = createMockLogger();
+
+    const mockDocument = createSeriesDocument({
+      images: [
+        {
+          type: 'LOGO',
+          locale: 'ja',
+          url: 'logo-ja',
+          width: 1400,
+          height: 300,
+        },
+        {
+          type: 'LOGO',
+          locale: null,
+          url: 'logo-universal',
+          width: 1000,
+          height: 200,
+        },
+        {
+          type: 'LOGO',
+          locale: 'ru',
+          url: 'logo-ru',
+          width: 1600,
+          height: 400,
+        },
+      ],
+    });
+    const repository = {
+      invoke: spy(async () => mockDocument),
+    } as unknown as SeriesRepository;
+
+    const service = new SeriesService(repository, logger);
+    const response = await service.aggregate({ anilist: 789 }, 'de-DE');
+
+    assertEquals(response.images.map(({ url }) => url), [
+      'logo-ja',
+      'logo-universal',
+    ]);
+  });
+
   it('does not mutate repository-returned document images when filtering the response', async () => {
     const { logger } = createMockLogger();
 
@@ -275,6 +360,31 @@ describe('SeriesService', () => {
       args: [
         'Failed to aggregate series',
         { query: { anilist: 789 }, cause: customError },
+      ],
+    });
+  });
+
+  it('wraps ARM lookup failures in InternalServerErrorException', async () => {
+    const { logger, spies } = createMockLogger();
+
+    const upstreamError = new Error('ARM timeout');
+    const repository = {
+      invoke: spy(async () => {
+        throw new SeriesArmLookupError(upstreamError);
+      }),
+    } as unknown as SeriesRepository;
+
+    const service = new SeriesService(repository, logger);
+
+    await assertRejects(
+      () => service.aggregate({ anilist: 789 }),
+      InternalServerErrorException,
+    );
+
+    assertSpyCall(spies.error, 0, {
+      args: [
+        'Failed to aggregate series',
+        { query: { anilist: 789 }, cause: upstreamError },
       ],
     });
   });

--- a/src/package/series/series.service.ts
+++ b/src/package/series/series.service.ts
@@ -1,9 +1,43 @@
-import { Injectable, InternalServerErrorException } from '@danet/core';
-import { BadRequestException } from '@danet/core';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@danet/core';
 import { LoggerService } from '@scope/logger';
-import { SeriesRepository } from './repository/index.ts';
+import { SeriesNotFoundError, SeriesRepository } from './repository/index.ts';
 import type { Series } from './series.types.ts';
 import type { SeriesQuery } from './series.types.ts';
+import type { SeriesImageAttributes } from './series.types.ts';
+import { selectSeriesImages } from './transformer/index.ts';
+
+const selectAggregateImages = (
+  images: SeriesImageAttributes[],
+  locale?: string | null,
+) => {
+  const selectedImages = selectSeriesImages(images, locale);
+  if (locale) {
+    return selectedImages;
+  }
+
+  const selectedUrls = new Set(selectedImages.map(({ url }) => url));
+  const fallbackTypes = new Set<SeriesImageAttributes['type']>();
+
+  return [
+    ...selectedImages,
+    ...selectSeriesImages(
+      images.filter(({ url }) => !selectedUrls.has(url)),
+      'fallback',
+    ).filter(({ type }) => {
+      if (fallbackTypes.has(type)) {
+        return false;
+      }
+
+      fallbackTypes.add(type);
+      return true;
+    }),
+  ];
+};
 
 @Injectable()
 export class SeriesService {
@@ -24,7 +58,7 @@ export class SeriesService {
    * @throws BadRequestException if query is empty or invalid
    * @throws NotFoundException if no upstream services return data
    */
-  async aggregate(query: SeriesQuery): Promise<Series> {
+  async aggregate(query: SeriesQuery, locale?: string | null): Promise<Series> {
     // Validate query has at least one identifier
     if (!query || Object.keys(query).length === 0) {
       this.logger.instance.warn('Provided empty query to aggregate series');
@@ -44,8 +78,13 @@ export class SeriesService {
       return {
         id: _id.toHexString(),
         ...entity,
+        images: selectAggregateImages(entity.images, locale),
       } satisfies Series;
     } catch (error) {
+      if (error instanceof SeriesNotFoundError) {
+        throw new NotFoundException();
+      }
+
       this.logger.instance.error('Failed to aggregate series', {
         query,
         cause: error,

--- a/src/package/series/series.service.ts
+++ b/src/package/series/series.service.ts
@@ -5,39 +5,14 @@ import {
   NotFoundException,
 } from '@danet/core';
 import { LoggerService } from '@scope/logger';
-import { SeriesNotFoundError, SeriesRepository } from './repository/index.ts';
+import {
+  SeriesArmLookupError,
+  SeriesNotFoundError,
+  SeriesRepository,
+} from './repository/index.ts';
 import type { Series } from './series.types.ts';
 import type { SeriesQuery } from './series.types.ts';
-import type { SeriesImageAttributes } from './series.types.ts';
 import { selectSeriesImages } from './transformer/index.ts';
-
-const selectAggregateImages = (
-  images: SeriesImageAttributes[],
-  locale?: string | null,
-) => {
-  const selectedImages = selectSeriesImages(images, locale);
-  if (locale) {
-    return selectedImages;
-  }
-
-  const selectedUrls = new Set(selectedImages.map(({ url }) => url));
-  const fallbackTypes = new Set<SeriesImageAttributes['type']>();
-
-  return [
-    ...selectedImages,
-    ...selectSeriesImages(
-      images.filter(({ url }) => !selectedUrls.has(url)),
-      'fallback',
-    ).filter(({ type }) => {
-      if (fallbackTypes.has(type)) {
-        return false;
-      }
-
-      fallbackTypes.add(type);
-      return true;
-    }),
-  ];
-};
 
 @Injectable()
 export class SeriesService {
@@ -78,16 +53,18 @@ export class SeriesService {
       return {
         id: _id.toHexString(),
         ...entity,
-        images: selectAggregateImages(entity.images, locale),
+        images: selectSeriesImages(entity.images, locale),
       } satisfies Series;
     } catch (error) {
       if (error instanceof SeriesNotFoundError) {
         throw new NotFoundException();
       }
 
+      const cause = error instanceof SeriesArmLookupError ? error.cause : error;
+
       this.logger.instance.error('Failed to aggregate series', {
         query,
-        cause: error,
+        cause,
       });
       throw new InternalServerErrorException();
     }

--- a/src/package/series/transformer/index.ts
+++ b/src/package/series/transformer/index.ts
@@ -1,1 +1,2 @@
 export * from './series.transformer.ts';
+export * from './series.image-selection.ts';

--- a/src/package/series/transformer/series.image-selection.test.ts
+++ b/src/package/series/transformer/series.image-selection.test.ts
@@ -70,7 +70,46 @@ describe('series.image-selection', () => {
     );
   });
 
-  it('should choose the best available image when no preferred or universal image exists', () => {
+  it('should prefer the device locale before universal fallback when jp is missing', () => {
+    const images = [
+      image('POSTER', null, 'poster-universal'),
+      image('POSTER', 'en', 'poster-en'),
+      image('POSTER', 'fr', 'poster-fr'),
+    ];
+
+    assertEquals(
+      selectSeriesImages(images, 'en-US').map((entry) => entry.url),
+      ['poster-en', 'poster-universal'],
+    );
+  });
+
+  it('should stop at universal fallback for locale-specific requests', () => {
+    const images = [
+      image('LOGO', 'ja', 'logo-ja', 1400, 300),
+      image('LOGO', null, 'logo-universal', 1000, 200),
+      image('LOGO', 'ru', 'logo-ru', 1600, 400),
+    ];
+
+    assertEquals(
+      selectSeriesImages(images, 'de-DE').map((entry) => entry.url),
+      ['logo-ja', 'logo-universal'],
+    );
+  });
+
+  it('should treat ja and jp as the same japanese bucket', () => {
+    const images = [
+      image('POSTER', 'ja', 'poster-ja'),
+      image('POSTER', 'jp', 'poster-jp'),
+      image('POSTER', 'en', 'poster-en'),
+    ];
+
+    assertEquals(
+      selectSeriesImages(images, 'ja-JP').map((entry) => entry.url),
+      ['poster-ja'],
+    );
+  });
+
+  it('should not choose unrelated locale images when no preferred or universal image exists', () => {
     const images = [
       image('LOGO', 'fr', 'logo-fr-small', 400, 100),
       image('LOGO', 'es', 'logo-es-large', 1200, 300),
@@ -79,6 +118,19 @@ describe('series.image-selection', () => {
 
     assertEquals(
       selectSeriesImages(images, 'en-US').map((entry) => entry.url),
+      [],
+    );
+  });
+
+  it('should choose the best available images when locale is missing', () => {
+    const images = [
+      image('LOGO', 'fr', 'logo-fr-small', 400, 100),
+      image('LOGO', 'es', 'logo-es-large', 1200, 300),
+      image('LOGO', 'de', 'logo-de-medium', 800, 200),
+    ];
+
+    assertEquals(
+      selectSeriesImages(images).map((entry) => entry.url),
       ['logo-es-large', 'logo-de-medium'],
     );
   });

--- a/src/package/series/transformer/series.image-selection.test.ts
+++ b/src/package/series/transformer/series.image-selection.test.ts
@@ -1,0 +1,123 @@
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+import type { SeriesImageAttributes } from '../series.types.ts';
+import { selectSeriesImages } from './series.image-selection.ts';
+
+const image = (
+  type: SeriesImageAttributes['type'],
+  locale: string | null,
+  url: string,
+  width = 1000,
+  height = 1500,
+): SeriesImageAttributes => ({
+  type,
+  locale,
+  url,
+  width,
+  height,
+});
+
+describe('series.image-selection', () => {
+  it('should derive the device language from locale values', () => {
+    const images = [
+      image('POSTER', 'jp', 'poster-jp'),
+      image('POSTER', 'en', 'poster-en'),
+      image('POSTER', 'en-US', 'poster-en-us'),
+    ];
+
+    assertEquals(
+      selectSeriesImages(images, 'en-US').map((entry) => entry.url),
+      ['poster-jp', 'poster-en'],
+    );
+  });
+
+  it('should normalize provider and device locale casing before matching buckets', () => {
+    const images = [
+      image('POSTER', 'JP', 'poster-jp'),
+      image('POSTER', 'EN-us', 'poster-en-us'),
+      image('POSTER', 'fr', 'poster-fr'),
+    ];
+
+    assertEquals(
+      selectSeriesImages(images, 'En-GB').map((entry) => entry.url),
+      ['poster-jp', 'poster-en-us'],
+    );
+  });
+
+  it('should select jp first and then the device locale for the same type', () => {
+    const images = [
+      image('POSTER', 'en', 'poster-en'),
+      image('POSTER', 'jp', 'poster-jp'),
+      image('BACKDROP', 'jp', 'backdrop-jp'),
+      image('BACKDROP', 'en', 'backdrop-en'),
+    ];
+
+    assertEquals(
+      selectSeriesImages(images, 'en-GB').map((entry) => entry.url),
+      ['poster-jp', 'poster-en', 'backdrop-jp', 'backdrop-en'],
+    );
+  });
+
+  it('should use universal images as fallback when preferred locale is missing', () => {
+    const images = [
+      image('POSTER', 'jp', 'poster-jp'),
+      image('POSTER', null, 'poster-universal'),
+    ];
+
+    assertEquals(
+      selectSeriesImages(images, 'en-US').map((entry) => entry.url),
+      ['poster-jp', 'poster-universal'],
+    );
+  });
+
+  it('should choose the best available image when no preferred or universal image exists', () => {
+    const images = [
+      image('LOGO', 'fr', 'logo-fr-small', 400, 100),
+      image('LOGO', 'es', 'logo-es-large', 1200, 300),
+      image('LOGO', 'de', 'logo-de-medium', 800, 200),
+    ];
+
+    assertEquals(
+      selectSeriesImages(images, 'en-US').map((entry) => entry.url),
+      ['logo-es-large', 'logo-de-medium'],
+    );
+  });
+
+  it('should prevent duplicate images when preferred buckets collapse or fallback repeats', () => {
+    const images = [
+      image('POSTER', 'jp', 'poster-jp'),
+      image('BACKDROP', null, 'backdrop-universal'),
+    ];
+
+    assertEquals(
+      selectSeriesImages(images, 'jp-JP').map((entry) => entry.url),
+      ['poster-jp', 'backdrop-universal'],
+    );
+  });
+
+  it('should not return the same image twice across different types', () => {
+    const images = [
+      image('POSTER', 'jp', 'shared-image'),
+      image('BACKDROP', 'jp', 'shared-image'),
+      image('BACKDROP', 'en', 'backdrop-en'),
+    ];
+
+    assertEquals(
+      selectSeriesImages(images, 'en-US').map((entry) => entry.url),
+      ['shared-image', 'backdrop-en'],
+    );
+  });
+
+  it('should use source order as the final tie-break', () => {
+    const images = [
+      image('POSTER', 'jp', 'poster-jp-first', 1000, 1500),
+      image('POSTER', 'jp', 'poster-jp-second', 1000, 1500),
+      image('POSTER', 'en', 'poster-en'),
+    ];
+
+    assertEquals(
+      selectSeriesImages(images, 'en-US').map((entry) => entry.url),
+      ['poster-jp-first', 'poster-en'],
+    );
+  });
+});

--- a/src/package/series/transformer/series.image-selection.ts
+++ b/src/package/series/transformer/series.image-selection.ts
@@ -12,7 +12,8 @@ const preferredBuckets = (locale?: string | null): string[] => {
     : ['jp'];
 };
 
-const maxImagesForLocale = (locale?: string | null) => locale ? preferredBuckets(locale).length : 2;
+const maxImagesForLocale = (locale?: string | null) =>
+  locale ? preferredBuckets(locale).length : 2;
 
 const shouldUseBestAvailableFallback = (locale?: string | null) => !locale;
 

--- a/src/package/series/transformer/series.image-selection.ts
+++ b/src/package/series/transformer/series.image-selection.ts
@@ -1,0 +1,112 @@
+import type { SeriesImageAttributes } from '../series.types.ts';
+
+type RankedImage = {
+  image: SeriesImageAttributes;
+  index: number;
+};
+
+const preferredBuckets = (locale?: string | null): string[] => {
+  const deviceLanguage = toLanguage(locale);
+  return deviceLanguage && deviceLanguage !== 'jp'
+    ? ['jp', deviceLanguage]
+    : ['jp'];
+};
+
+const toLanguage = (locale?: string | null): string | null => {
+  if (!locale) {
+    return null;
+  }
+
+  const [language] = locale.toLowerCase().split(/[-_]/);
+  return language || null;
+};
+
+const imageArea = ({ width, height }: SeriesImageAttributes) => width * height;
+
+const rankImage = (
+  candidate: RankedImage,
+  bucket: string,
+): [number, number, number] => {
+  const language = toLanguage(candidate.image.locale);
+  const localeRank = language === bucket ? 2 : language === null ? 1 : 0;
+
+  return [localeRank, imageArea(candidate.image), -candidate.index];
+};
+
+const compareRank = (
+  left: [number, number, number],
+  right: [number, number, number],
+) => {
+  for (let index = 0; index < left.length; index++) {
+    if (left[index] !== right[index]) {
+      return right[index] - left[index];
+    }
+  }
+
+  return 0;
+};
+
+const selectForBucket = (
+  images: RankedImage[],
+  bucket: string,
+  usedUrls: Set<string>,
+): RankedImage | null => {
+  let best: RankedImage | null = null;
+  let bestRank: [number, number, number] | null = null;
+
+  for (const candidate of images) {
+    if (usedUrls.has(candidate.image.url)) {
+      continue;
+    }
+
+    const candidateRank = rankImage(candidate, bucket);
+    if (!bestRank || compareRank(bestRank, candidateRank) > 0) {
+      best = candidate;
+      bestRank = candidateRank;
+    }
+  }
+
+  return best;
+};
+
+export const selectSeriesImages = (
+  images: SeriesImageAttributes[],
+  locale?: string | null,
+): SeriesImageAttributes[] => {
+  const groupedImages = new Map<SeriesImageAttributes['type'], RankedImage[]>();
+  const typeOrder: SeriesImageAttributes['type'][] = [];
+
+  for (const [index, image] of images.entries()) {
+    const group = groupedImages.get(image.type);
+    if (group) {
+      group.push({ image, index });
+      continue;
+    }
+
+    groupedImages.set(image.type, [{ image, index }]);
+    typeOrder.push(image.type);
+  }
+
+  const selectedImages: SeriesImageAttributes[] = [];
+  const buckets = preferredBuckets(locale);
+  const usedUrls = new Set<string>();
+
+  for (const type of typeOrder) {
+    const group = groupedImages.get(type);
+    if (!group) {
+      continue;
+    }
+
+    for (const bucket of buckets) {
+      const selected = selectForBucket(group, bucket, usedUrls);
+      if (!selected) {
+        continue;
+      }
+
+      usedUrls.add(selected.image.url);
+      selectedImages.push(selected.image);
+    }
+  }
+
+  return selectedImages;
+};

--- a/src/package/series/transformer/series.image-selection.ts
+++ b/src/package/series/transformer/series.image-selection.ts
@@ -6,10 +6,22 @@ type RankedImage = {
 };
 
 const preferredBuckets = (locale?: string | null): string[] => {
-  const deviceLanguage = toLanguage(locale);
+  const deviceLanguage = toBucketLanguage(toLanguage(locale));
   return deviceLanguage && deviceLanguage !== 'jp'
     ? ['jp', deviceLanguage]
     : ['jp'];
+};
+
+const maxImagesForLocale = (locale?: string | null) => locale ? preferredBuckets(locale).length : 2;
+
+const shouldUseBestAvailableFallback = (locale?: string | null) => !locale;
+
+const toBucketLanguage = (language?: string | null): string | null => {
+  if (!language) {
+    return null;
+  }
+
+  return language === 'ja' ? 'jp' : language;
 };
 
 const toLanguage = (locale?: string | null): string | null => {
@@ -25,10 +37,18 @@ const imageArea = ({ width, height }: SeriesImageAttributes) => width * height;
 
 const rankImage = (
   candidate: RankedImage,
-  bucket: string,
+  bucket?: string | null,
 ): [number, number, number] => {
-  const language = toLanguage(candidate.image.locale);
-  const localeRank = language === bucket ? 2 : language === null ? 1 : 0;
+  const language = toBucketLanguage(toLanguage(candidate.image.locale));
+  let localeRank = 0;
+
+  if (bucket === null) {
+    localeRank = language === null ? 1 : 0;
+  } else if (!bucket) {
+    localeRank = 1;
+  } else {
+    localeRank = language === bucket ? 1 : 0;
+  }
 
   return [localeRank, imageArea(candidate.image), -candidate.index];
 };
@@ -48,7 +68,7 @@ const compareRank = (
 
 const selectForBucket = (
   images: RankedImage[],
-  bucket: string,
+  bucket: string | null | undefined,
   usedUrls: Set<string>,
 ): RankedImage | null => {
   let best: RankedImage | null = null;
@@ -60,6 +80,10 @@ const selectForBucket = (
     }
 
     const candidateRank = rankImage(candidate, bucket);
+    if (bucket !== undefined && candidateRank[0] === 0) {
+      continue;
+    }
+
     if (!bestRank || compareRank(bestRank, candidateRank) > 0) {
       best = candidate;
       bestRank = candidateRank;
@@ -90,12 +114,15 @@ export const selectSeriesImages = (
   const selectedImages: SeriesImageAttributes[] = [];
   const buckets = preferredBuckets(locale);
   const usedUrls = new Set<string>();
+  const maxImagesPerType = maxImagesForLocale(locale);
 
   for (const type of typeOrder) {
     const group = groupedImages.get(type);
     if (!group) {
       continue;
     }
+
+    let selectedForType = 0;
 
     for (const bucket of buckets) {
       const selected = selectForBucket(group, bucket, usedUrls);
@@ -105,6 +132,39 @@ export const selectSeriesImages = (
 
       usedUrls.add(selected.image.url);
       selectedImages.push(selected.image);
+      selectedForType += 1;
+
+      if (selectedForType >= maxImagesPerType) {
+        break;
+      }
+    }
+
+    if (selectedForType >= maxImagesPerType) {
+      continue;
+    }
+
+    const universal = selectForBucket(group, null, usedUrls);
+    if (universal) {
+      usedUrls.add(universal.image.url);
+      selectedImages.push(universal.image);
+      selectedForType += 1;
+    }
+
+    if (selectedForType >= maxImagesPerType) {
+      continue;
+    }
+
+    if (shouldUseBestAvailableFallback(locale)) {
+      while (selectedForType < maxImagesPerType) {
+        const fallback = selectForBucket(group, undefined, usedUrls);
+        if (!fallback) {
+          break;
+        }
+
+        usedUrls.add(fallback.image.url);
+        selectedImages.push(fallback.image);
+        selectedForType += 1;
+      }
     }
   }
 


### PR DESCRIPTION
# AniTrend Pull Request

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/AniTrend/on-the-edge/blob/dev/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure you've done the following:

- You have followed our [**contributing guidelines**](https://github.com/AniTrend/on-the-edge/blob/dev/CONTRIBUTING.md)
- Double checked that your branch is based on `dev` and targets `dev` (where applicable)
- Pull request has tests (if applicable)
- Documentation is updated (if necessary)
- Description explains the issue/use-case resolved

## Description

Optimizes `v1/series` image payloads by keeping cached canonical `SeriesDocument` data intact while returning locale-focused images in the HTTP response.

This change adds deterministic image selection that prefers Japanese artwork first, then the device language, and finally universal (`null`) images for locale-specific requests. It intentionally stops before unrelated locales, so requests like `de-DE` no longer surface assets such as `ru` when no German image exists. Requests without a locale still keep the broader fallback behavior so the endpoint can return a useful secondary image when available.

The controller now reads client locale from request context and passes it into `SeriesService`, where response-only filtering happens after repository retrieval. The series resolver also distinguishes true not-found cases from ARM upstream lookup failures with typed errors so ARM failures continue to surface as server errors rather than `404` responses.

Tests cover the image-selection helper, service integration, controller locale pass-through, ARM lookup error handling, and broader `series` module verification. Documentation was added under `docs/superpowers/specs/2026-05-25-series-endpoint-image-optimization-design.md` and `docs/superpowers/plans/2026-05-25-series-endpoint-image-optimization.md`.

Verification run for this branch:
- `deno task test -- --filter "series"`
- `deno task check`
- `deno task lint`
- manual local `curl` validation for no locale, `en-US`, `ja-JP`, and `de-DE` requests

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [Apache License, Version 2.0](https://github.com/AniTrend/on-the-edge/blob/dev/LICENSE.md).
