### PR TITLE
refactor(experiment): remove enable-animethemes-api feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@
 	 cp .env.example .env
 	 ```
 	 Fill in provider URLs/keys (`TMDB`, `TRAKT`, `ANIME_THEMES`, GrowthBook, Mongo creds, etc.). Keep secrets out of source control.
-	 `ANIME_THEMES` is the active base URL for AnimeThemes lookups. `THEMES` is retained only as a legacy placeholder while the compatibility facade in `src/service/theme/` remains in place.
-	 GrowthBook flag `enable-animethemes-api` switches `ThemeService` between the legacy `THEMES` endpoint and the AnimeThemes API during rollout.
+	 `ANIME_THEMES` is the active base URL for AnimeThemes lookups.
 3. **Install dependencies** (cached by Deno on demand)
 	 ```bash
 	 deno task cache

--- a/src/experiment/experiment.service.ts
+++ b/src/experiment/experiment.service.ts
@@ -37,7 +37,6 @@ export class ExperimentService implements OnAppClose {
       AppFeatures,
       | 'news-refactor-api'
       | 'enable-analytics'
-      | 'enable-animethemes-api'
       | 'episode-align-title-sim'
       | 'episodes-diagnostics'
       | 'enable-skyhook-source'

--- a/src/experiment/experiment.types.ts
+++ b/src/experiment/experiment.types.ts
@@ -7,7 +7,6 @@ export type AppFeatures = {
   'platform-source'?: PlatformSource;
   'news-refactor-api': boolean;
   'enable-analytics': boolean;
-  'enable-animethemes-api'?: boolean;
   // Numeric threshold for fuzzy title alignment (0..1). If absent, fallback disabled
   'episode-align-title-sim'?: number;
   // Enable emitting diagnostics on episodes response

--- a/src/package/series/repository/series.repository.aggregation.test.ts
+++ b/src/package/series/repository/series.repository.aggregation.test.ts
@@ -257,7 +257,7 @@ describe.skip('SeriesRepository aggregation', () => {
       mocks.services.arm,
       mocks.services.thexem,
       mocks.services.animeThemes,
-      createMockExperiment({ 'enable-animethemes-api': true }),
+      createMockExperiment({}),
       logger,
     );
   }

--- a/src/package/series/repository/series.resolver.test.ts
+++ b/src/package/series/repository/series.resolver.test.ts
@@ -119,11 +119,9 @@ const animeThemesLookup: AnimeThemesLookupModel = {
   }],
 };
 
-function createResolver(flagEnabled: boolean) {
+function createResolver() {
   const { logger } = createMockLogger();
-  const experiment = createMockExperiment({
-    'enable-animethemes-api': flagEnabled,
-  });
+  const experiment = createMockExperiment({});
   const getThemesForAnime = spy(async () => animeThemesLookup);
 
   const resolver = new SeriesResolver(
@@ -146,17 +144,8 @@ function createResolver(flagEnabled: boolean) {
 }
 
 describe('SeriesResolver', () => {
-  it('skips AnimeThemes when enable-animethemes-api is disabled', async () => {
-    const { resolver, getThemesForAnime } = createResolver(false);
-
-    const result = await resolver.resolve({ anilist: 400 });
-
-    assertSpyCalls(getThemesForAnime, 0);
-    assertEquals('animethemes' in result ? result.animethemes : [], []);
-  });
-
-  it('uses AnimeThemes when enable-animethemes-api is enabled', async () => {
-    const { resolver, getThemesForAnime } = createResolver(true);
+  it('resolves AnimeThemes correctly', async () => {
+    const { resolver, getThemesForAnime } = createResolver();
 
     const result = await resolver.resolve({ anilist: 400 });
 
@@ -169,9 +158,7 @@ describe('SeriesResolver', () => {
 
   it('throws SeriesNotFoundError when no relation can be resolved', async () => {
     const { logger } = createMockLogger();
-    const experiment = createMockExperiment({
-      'enable-animethemes-api': false,
-    });
+    const experiment = createMockExperiment({});
 
     const resolver = new SeriesResolver(
       { getShow: async () => undefined } as unknown as TraktService,
@@ -199,9 +186,7 @@ describe('SeriesResolver', () => {
 
   it('throws SeriesArmLookupError when ARM lookup fails upstream', async () => {
     const { logger } = createMockLogger();
-    const experiment = createMockExperiment({
-      'enable-animethemes-api': false,
-    });
+    const experiment = createMockExperiment({});
     const upstreamError = new Error('ARM timeout');
 
     const resolver = new SeriesResolver(

--- a/src/package/series/repository/series.resolver.ts
+++ b/src/package/series/repository/series.resolver.ts
@@ -168,15 +168,6 @@ export class SeriesResolver {
     if (!malId) {
       return undefined;
     }
-    if (!this.experiment.isEnabled('enable-animethemes-api')) {
-      this.logger.instance.info(
-        'Skipping AnimeThemes fetch because feature flag is disabled',
-        {
-          malId,
-        },
-      );
-      return undefined;
-    }
     try {
       return await this.animeThemes.getThemesForAnime(malId);
     } catch (error) {


### PR DESCRIPTION
# AniTrend Pull Request

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/AniTrend/on-the-edge/blob/dev/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

## Checklist

- [x] Followed contributing guidelines
- [x] Branch is based on `dev` and targets `dev`
- [x] Pull request has tests
- [x] Documentation updated

## Description

Removes the `enable-animethemes-api` feature flag gating as it is no longer required. The AnimeThemes API integration is now always enabled by default.

### Changes Made

- Removed `enable-animethemes-api` from `AppFeatures` type definition
- Removed feature flag check in `SeriesResolver.resolveAnimeThemes()`
- Removed feature flag-specific tests from `series.resolver.test.ts`
- Updated mock experiment setup in `series.repository.aggregation.test.ts`
- Updated README documentation to remove feature flag reference

All tests pass successfully.

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [Apache License, Version 2.0](https://github.com/AniTrend/on-the-edge/blob/dev/LICENSE.md).