### PR TITLE
fix: tolerate null ARM responses and purge invalid news cache

### DIFF
--- a/src/database/collection/mongo.collection.adapter.ts
+++ b/src/database/collection/mongo.collection.adapter.ts
@@ -1,6 +1,7 @@
 import type {
   BulkWriteOptions,
   Collection as MongoCollection,
+  DeleteResult,
   Document,
   Filter,
   FindOneAndReplaceOptions,
@@ -81,5 +82,9 @@ export class MongoCollectionAdapter<T extends Document>
     });
 
     return result;
+  }
+
+  async deleteMany(filter: Filter<T>): Promise<DeleteResult> {
+    return await this.collection.deleteMany(filter);
   }
 }

--- a/src/database/collection/mongo.collection.interface.ts
+++ b/src/database/collection/mongo.collection.interface.ts
@@ -1,5 +1,6 @@
 import type {
   BulkWriteOptions,
+  DeleteResult,
   Document,
   Filter,
   FindOneAndReplaceOptions,
@@ -45,4 +46,6 @@ export interface Collection<T extends Document> {
     update: UpdateFilter<T>,
     options?: UpdateOptions,
   ): Promise<UpdateResult>;
+
+  deleteMany(filter: Filter<T>): Promise<DeleteResult>;
 }

--- a/src/database/testing/memory-collection.ts
+++ b/src/database/testing/memory-collection.ts
@@ -1,5 +1,6 @@
 import {
   BulkWriteOptions,
+  DeleteResult,
   Document,
   Filter,
   FindOneAndReplaceOptions,
@@ -76,6 +77,12 @@ export class InMemoryCollection<T extends Document> implements Collection<T> {
         if ('$gt' in value && numValue <= (value.$gt as number)) return false;
         if ('$lte' in value && numValue > (value.$lte as number)) return false;
         if ('$gte' in value && numValue < (value.$gte as number)) return false;
+        if (
+          '$in' in value && Array.isArray(value.$in) &&
+          !value.$in.includes(docValue)
+        ) {
+          return false;
+        }
         if ('$exists' in value && (docValue !== undefined) !== value.$exists) {
           return false;
         }
@@ -296,6 +303,19 @@ export class InMemoryCollection<T extends Document> implements Collection<T> {
       upsertedCount: 0,
       upsertedId: null,
     } as UpdateResult;
+  }
+
+  async deleteMany(filter: Filter<T>): Promise<DeleteResult> {
+    const docs = await this.find(filter);
+
+    docs.forEach((doc) => {
+      this.data.delete(doc._id);
+    });
+
+    return {
+      acknowledged: true,
+      deletedCount: docs.length,
+    } as DeleteResult;
   }
 
   /**

--- a/src/package/news/news.repository.test.ts
+++ b/src/package/news/news.repository.test.ts
@@ -5,6 +5,7 @@ import { type MongoService } from '@scope/database';
 import { InMemoryCollection } from '@scope/database/testing';
 import type {
   BulkWriteOptions,
+  DeleteResult,
   Filter,
   FindOneAndReplaceOptions,
   FindOptions,
@@ -56,6 +57,10 @@ class MockMongoCollection {
     options?: UpdateOptions,
   ) {
     return this.memoryCollection.updateOne(filter, update, options);
+  }
+
+  deleteMany(filter: Filter<NewsDocument>): Promise<DeleteResult> {
+    return this.memoryCollection.deleteMany(filter);
   }
 
   findOneAndReplace(
@@ -140,6 +145,31 @@ describe('NewsRepository', () => {
     assertEquals(result.data[0].publishedOn, 1_735_700_001);
     assertExists(result.first);
     assertEquals(result.first, result.last);
+  });
+
+  it('purges cached documents that violate the public news schema', async () => {
+    const repository = new NewsRepository(
+      new MockMongoService(
+        new MockMongoCollection(collection),
+      ) as unknown as MongoService,
+      new MockOtakumodeService() as unknown as OtakumodeService,
+      logger,
+    );
+
+    await collection.insertMany([
+      createNewsDocument({ id: 'valid-news', publishedOn: 1_735_700_001 }),
+      createNewsDocument({
+        id: 'invalid-news',
+        publishedOn: null as unknown as number,
+      }),
+    ]);
+
+    await repository.paging({ limit: 10 });
+
+    assertEquals(await collection.countDocuments({}), 1);
+    assertEquals((await collection.find({}, {})).map((item) => item.id), [
+      'valid-news',
+    ]);
   });
 
   it('drops remote RSS items with non-finite publishedOn values before insert', async () => {

--- a/src/package/news/news.repository.ts
+++ b/src/package/news/news.repository.ts
@@ -58,14 +58,32 @@ export class NewsRepository {
     };
   }
 
-  private toPublicNewsBatch(documents: NewsDocumentWithId[]): Array<{
-    cursor: string;
-    item: News;
-  }> {
-    return documents.flatMap((document) => {
+  private async toPublicNewsBatch(
+    documents: NewsDocumentWithId[],
+  ): Promise<
+    Array<{
+      cursor: string;
+      item: News;
+    }>
+  > {
+    const invalidDocumentIds: ObjectId[] = [];
+    const payload = documents.flatMap((document) => {
       const parsed = this.toPublicNews(document);
-      return parsed ? [parsed] : [];
+      if (parsed) {
+        return [parsed];
+      }
+
+      invalidDocumentIds.push(document._id);
+      return [];
     });
+
+    if (invalidDocumentIds.length > 0) {
+      await this.collection.deleteMany({
+        _id: { $in: invalidDocumentIds },
+      });
+    }
+
+    return payload;
   }
 
   async lastUpdatedAt(): Promise<number | undefined> {
@@ -103,7 +121,9 @@ export class NewsRepository {
           limit: 15,
         };
         const results = await this.collection.find({}, options);
-        const payload = this.toPublicNewsBatch(results).map(({ item }) => item);
+        const payload = (await this.toPublicNewsBatch(results)).map((
+          { item },
+        ) => item);
         if (payload.length > 0 || results.length === 0) {
           return payload;
         }
@@ -154,7 +174,7 @@ export class NewsRepository {
       { sort, limit: query.limit },
     );
 
-    const payload = this.toPublicNewsBatch(documents);
+    const payload = await this.toPublicNewsBatch(documents);
     const data = payload.map(({ item }) => item);
 
     const count = data.length;

--- a/src/service/arm/arm.service.test.ts
+++ b/src/service/arm/arm.service.test.ts
@@ -76,4 +76,17 @@ describe('ArmService', () => {
     assertEquals(result[0].anilist, 20);
     assertEquals(result[1].imdb, 'tt789');
   });
+
+  it('returns undefined when ids lookup responds with null', async () => {
+    mockFetch('https://arm.test/api/v2/ids?source=anilist&id=12373', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body: 'null',
+    });
+
+    const service = new ArmService(config, logger);
+    const result = await service.getRelationsById('anilist', 12373);
+
+    assertEquals(result, undefined);
+  });
 });

--- a/src/service/arm/arm.service.ts
+++ b/src/service/arm/arm.service.ts
@@ -14,6 +14,14 @@ import {
 export class ArmService {
   private readonly client: RequestClient;
 
+  private parseRelation(data: unknown): SeriesRelationId | undefined {
+    if (data == null) {
+      return undefined;
+    }
+
+    return ArmSchema.parse(data);
+  }
+
   constructor(
     private readonly secret: SecretService,
     private readonly logger: LoggerService,
@@ -44,13 +52,13 @@ export class ArmService {
       );
     }
 
-    return ArmSchema.parse(data);
+    return this.parseRelation(data);
   };
 
   getRelationsById = async (
     source: SeriesRelationSource,
     id: number,
-  ): Promise<SeriesRelationId> => {
+  ): Promise<SeriesRelationId | undefined> => {
     const { data, status } = await this.client
       .get('/api/v2/ids', {
         params: {
@@ -65,7 +73,7 @@ export class ArmService {
       );
     }
 
-    return ArmSchema.parse(data);
+    return this.parseRelation(data);
   };
 
   getRelationsByTvdb = async (


### PR DESCRIPTION
# AniTrend Pull Request

- [x] You have followed our [**contributing guidelines**](https://github.com/AniTrend/on-the-edge/blob/dev/CONTRIBUTING.md)
- [x] Double checked that your branch is based on `dev` and targets `dev` (where applicable)
- [x] Pull request has tests (if applicable)
- [ ] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved

## Description

This change addresses two production failure modes observed in logs:

1. ARM series aggregation now treats top-level `null` `/api/v2/ids` responses as an unresolved relation instead of throwing a schema error.
2. News cache reads now purge invalid cached news documents after detection so stale rows with missing `publishedOn` do not keep triggering repeated warning logs.

Validation run:
- `deno fmt --check`
- `deno lint`
- `deno task check`
- `deno task test`
- `deno task build`

Additional verification:
- confirmed via live upstream `curl` that `https://arm.haglund.dev/api/v2/ids?source=anilist&id=12373` currently returns `null`
- confirmed live news feed remains parseable from `https://otakumode.com/news/feed`
