### PR TITLE
fix(types): fix deploy workflow by correcting zod default exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           cache: true
-          deno-version: 2.8.2
+          deno-version: 2.8.3
       - name: Config properties file
         run: bash .github/scripts/config-env.sh
       - name: Run lint checks
@@ -36,7 +36,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           cache: true
-          deno-version: 2.8.2
+          deno-version: 2.8.3
       - name: Config properties file
         run: bash .github/scripts/config-env.sh
       - name: Check code format
@@ -52,7 +52,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           cache: true
-          deno-version: 2.8.2
+          deno-version: 2.8.3
       - name: Config properties file
         run: bash .github/scripts/config-env.sh
       - name: Run checks
@@ -69,7 +69,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           cache: true
-          deno-version: 2.8.2
+          deno-version: 2.8.3
       - name: Config properties file
         run: bash .github/scripts/config-env.sh
       - name: Run tests
@@ -108,7 +108,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           cache: true
-          deno-version: 2.8.2
+          deno-version: 2.8.3
       - name: Config properties file
         run: bash .github/scripts/config-env.sh
       - name: Generate swagger spec
@@ -132,7 +132,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           cache: true
-          deno-version: 2.8.2
+          deno-version: 2.8.3
       - name: Config properties file
         run: bash .github/scripts/config-env.sh
       - name: Compile Application

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -19,7 +19,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           cache: true
-          deno-version: 2.8.2
+          deno-version: 2.8.3
       - name: Config properties file
         run: bash .github/scripts/config-env.sh
       - name: Cache dependencies

--- a/.github/workflows/swagger-release.yml
+++ b/.github/workflows/swagger-release.yml
@@ -78,7 +78,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           cache: true
-          deno-version: 2.8.2
+          deno-version: 2.8.3
       - name: Config properties file
         run: bash .github/scripts/config-env.sh
       - name: Generate swagger spec

--- a/src/package/config/config.schema.ts
+++ b/src/package/config/config.schema.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import { z } from 'zod';
 
 const SettingsSchema = z.object({
   analyticsEnabled: z.boolean(),

--- a/src/package/config/config.types.ts
+++ b/src/package/config/config.types.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import { z } from 'zod';
 import { ConfigSchema } from './config.schema.ts';
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/src/package/news/news.types.ts
+++ b/src/package/news/news.types.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import { z } from 'zod';
 import {
   NewsPagingQuerySchema,
   NewsPagingSchema,

--- a/src/package/series/series.types.ts
+++ b/src/package/series/series.types.ts
@@ -1,5 +1,5 @@
 import { SeriesQuerySchema } from './series.schema.ts';
-import z from 'zod';
+import { z } from 'zod';
 import {
   AnimeMetadataSchema,
   MangaMetadataSchema,

--- a/src/service/arm/arm.types.ts
+++ b/src/service/arm/arm.types.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import { z } from 'zod';
 import { ArmSchema } from './arm.schema.ts';
 
 export type SeriesRelationId = z.infer<typeof ArmSchema>;

--- a/src/service/tmdb/tmdb.types.ts
+++ b/src/service/tmdb/tmdb.types.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import { z } from 'zod';
 import type {
   ConfigurationSchema,
   CrewSchema,


### PR DESCRIPTION
## Summary

The deploy workflow fails because Deno 2.8.3 (used in Docker) is stricter about default exports. Six files use `import z from 'zod'` but zod doesn't expose a default export, producing TS1192 errors during `deno task check` in the Docker build stage.

## Changes

- Replace `import z from 'zod'` → `import { z } from 'zod'` in 6 files:
  - `src/package/config/config.schema.ts`
  - `src/package/config/config.types.ts`
  - `src/package/news/news.types.ts`
  - `src/package/series/series.types.ts`
  - `src/service/arm/arm.types.ts`
  - `src/service/tmdb/tmdb.types.ts`
- Sync all workflow `deno-version` values from 2.8.2 → 2.8.3 to match Dockerfile across `ci.yml`, `swagger-release.yml`, `quality.yml`

## Verification

| Gate | Before | After |
|------|--------|-------|
| `deno check` | 26+ errors | 0 errors |
| `deno fmt:check` | 294 files clean | 294 files clean |
| `deno lint` | 282 files clean | 282 files clean |
| `deno test` | 64 passed | 64 passed |