### PR TITLE
feat(config): add stable identities and payload validation for navigation entries

### DIFF
--- a/src/package/config/config.contract.ts
+++ b/src/package/config/config.contract.ts
@@ -41,6 +41,10 @@ export const ConfigNavigationGroupContract = z.object({
 });
 
 export const ConfigNavigationItemContract = z.object({
+  key: z.string().min(1).openapi({
+    description:
+      'Stable identity for persistence, dedupe, and diffing. Must not change unless a deliberate migration is intended.',
+  }),
   criteria: z.string(),
   destination: z.string(),
   i18n: z.string(),

--- a/src/package/config/config.document.ts
+++ b/src/package/config/config.document.ts
@@ -1,4 +1,16 @@
 import { Config } from './config.types.ts';
 import { WithId } from 'mongodb';
 
-export type ConfigDocument = Omit<WithId<Config>, 'id' | 'settings'>;
+/** Raw MongoDB navigation item — key is optional because the transformer
+ * generates it from destination when absent in the persisted document. */
+type NavigationItemInput = Omit<Config['navigation'][number], 'key'> & {
+  key?: string | null;
+};
+
+export type ConfigDocument =
+  & WithId<
+    Omit<Config, 'id' | 'settings' | 'navigation'>
+  >
+  & {
+    navigation: NavigationItemInput[];
+  };

--- a/src/package/config/config.schema.ts
+++ b/src/package/config/config.schema.ts
@@ -15,6 +15,7 @@ const ImageSchema = z.object({
 });
 
 const NavigationItemSchema = z.object({
+  key: z.string().min(1),
   criteria: z.string(),
   destination: z.string(),
   i18n: z.string(),

--- a/src/package/config/config.service.test.ts
+++ b/src/package/config/config.service.test.ts
@@ -1,0 +1,316 @@
+import { describe, it } from '@std/testing/bdd';
+import { assertEquals, assertRejects } from '@std/assert';
+import { NotFoundException } from '@danet/core';
+import { createMockLogger } from '@scope/common/testing';
+import { ConfigService } from './config.service.ts';
+import { validateNavigation } from './config.validation.ts';
+import type { Config } from './config.types.ts';
+import type { ConfigRepository } from './config.repository.ts';
+import type { ExperimentService } from '@scope/experiment';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function validNavItem(
+  overrides?: Partial<Config['navigation'][number]>,
+): Config['navigation'][number] {
+  return {
+    key: 'home',
+    criteria: 'test',
+    destination: '/home',
+    i18n: 'nav.home',
+    icon: 'home',
+    group: { authenticated: false, i18n: 'nav.group.main' },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unit: validateNavigation
+// ---------------------------------------------------------------------------
+
+describe('validateNavigation', () => {
+  it('returns empty errors for a valid navigation array', () => {
+    const nav = [
+      validNavItem({ key: 'home', destination: '/home' }),
+      validNavItem({
+        key: 'search',
+        destination: '/search',
+        i18n: 'nav.search',
+        icon: 'search',
+        group: { authenticated: false, i18n: 'nav.group.main' },
+      }),
+    ];
+    const errors = validateNavigation(nav);
+    assertEquals(errors, []);
+  });
+
+  it('returns error when navigation array is empty', () => {
+    const errors = validateNavigation([]);
+    assertEquals(errors.length, 1);
+    assertEquals(
+      errors[0].message,
+      'Config navigation array is empty or missing',
+    );
+  });
+
+  it('returns error when navigation is null/undefined', () => {
+    const errors = validateNavigation(null as unknown as Config['navigation']);
+    assertEquals(errors.length, 1);
+    assertEquals(
+      errors[0].message,
+      'Config navigation array is empty or missing',
+    );
+  });
+
+  it('returns error when entry has no key', () => {
+    const nav = [
+      validNavItem({ key: undefined as unknown as string }),
+    ];
+    const errors = validateNavigation(nav);
+    assertEquals(errors.length, 1);
+    assertEquals(errors[0].message, 'navigation[0].key is empty or missing');
+    assertEquals(errors[0].field, 'navigation[0].key');
+  });
+
+  it('returns error when entry has empty key', () => {
+    const nav = [
+      validNavItem({ key: '' }),
+    ];
+    const errors = validateNavigation(nav);
+    assertEquals(errors.length, 1);
+    assertEquals(errors[0].message, 'navigation[0].key is empty or missing');
+  });
+
+  it('returns error when entry has no destination', () => {
+    const nav = [
+      validNavItem({ destination: undefined as unknown as string }),
+    ];
+    const errors = validateNavigation(nav);
+    assertEquals(errors.length, 1);
+    assertEquals(
+      errors[0].message,
+      'navigation[0].destination is empty or missing',
+    );
+    assertEquals(errors[0].field, 'navigation[0].destination');
+  });
+
+  it('returns error when entry has no i18n', () => {
+    const nav = [
+      validNavItem({ i18n: undefined as unknown as string }),
+    ];
+    const errors = validateNavigation(nav);
+    assertEquals(errors.length, 1);
+    assertEquals(errors[0].message, 'navigation[0].i18n is empty or missing');
+    assertEquals(errors[0].field, 'navigation[0].i18n');
+  });
+
+  it('returns error when entry has no icon', () => {
+    const nav = [
+      validNavItem({ icon: undefined as unknown as string }),
+    ];
+    const errors = validateNavigation(nav);
+    assertEquals(errors.length, 1);
+    assertEquals(errors[0].message, 'navigation[0].icon is empty or missing');
+    assertEquals(errors[0].field, 'navigation[0].icon');
+  });
+
+  it('returns error when entry has no group.i18n', () => {
+    const nav = [
+      validNavItem({
+        group: {
+          authenticated: false,
+          i18n: undefined as unknown as string,
+        },
+      }),
+    ];
+    const errors = validateNavigation(nav);
+    assertEquals(errors.length, 1);
+    assertEquals(
+      errors[0].message,
+      'navigation[0].group.i18n is empty or missing',
+    );
+    assertEquals(errors[0].field, 'navigation[0].group.i18n');
+  });
+
+  it('returns duplicate key error when two entries share the same key', () => {
+    const nav = [
+      validNavItem({ key: 'home', destination: '/home' }),
+      validNavItem({
+        key: 'home',
+        destination: '/home-alt',
+        i18n: 'nav.home',
+        icon: 'home',
+        group: { authenticated: false, i18n: 'nav.group.main' },
+      }),
+    ];
+    const errors = validateNavigation(nav);
+    assertEquals(errors.length, 1);
+    assertEquals(errors[0].message, 'Duplicate navigation key: "home"');
+    assertEquals(errors[0].field, 'key');
+  });
+
+  it('returns duplicate destination error when two entries share the same destination', () => {
+    const nav = [
+      validNavItem({ key: 'home', destination: '/same' }),
+      validNavItem({
+        key: 'home-alt',
+        destination: '/same',
+        i18n: 'nav.home',
+        icon: 'home',
+        group: { authenticated: false, i18n: 'nav.group.main' },
+      }),
+    ];
+    const errors = validateNavigation(nav);
+    assertEquals(errors.length, 1);
+    assertEquals(
+      errors[0].message,
+      'Duplicate navigation destination: "/same"',
+    );
+    assertEquals(errors[0].field, 'destination');
+  });
+
+  it('returns multiple errors when an entry is missing several fields', () => {
+    const nav = [
+      validNavItem({
+        key: undefined as unknown as string,
+        destination: undefined as unknown as string,
+        i18n: undefined as unknown as string,
+        icon: undefined as unknown as string,
+        group: {
+          authenticated: false,
+          i18n: undefined as unknown as string,
+        },
+      }),
+    ];
+    const errors = validateNavigation(nav);
+    // All five required fields should fail on the single entry
+    assertEquals(errors.length, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stub classes for integration tests
+// ---------------------------------------------------------------------------
+
+class ExperimentStub {
+  getFeatureValue<T>(_feature: string, defaultValue: T): T {
+    return defaultValue;
+  }
+  isEnabled(_feature: string): boolean {
+    return false;
+  }
+}
+
+type ConfigDocumentStub = {
+  _id: { toString(): string };
+  image: Record<string, string>;
+  genres: Array<{ name: string; mediaId: number }>;
+  navigation: Config['navigation'];
+};
+
+function makeDocumentStub(
+  overrides?: Partial<ConfigDocumentStub>,
+): ConfigDocumentStub {
+  return {
+    _id: { toString: () => '507f1f77bcf86cd799439011' },
+    image: {
+      banner: 'https://example.com/banner.jpg',
+      poster: 'https://example.com/poster.jpg',
+      loading: 'https://example.com/loading.jpg',
+      error: 'https://example.com/error.jpg',
+      info: 'https://example.com/info.jpg',
+      default: 'https://example.com/default.jpg',
+    },
+    genres: [{ name: 'Action', mediaId: 1 }],
+    navigation: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Integration: ConfigService.getConfig
+// ---------------------------------------------------------------------------
+
+describe('ConfigService.getConfig', () => {
+  it('returns config when repository has a valid document with navigation items', async () => {
+    const repository = {
+      getConfig: async () =>
+        makeDocumentStub({
+          navigation: [
+            validNavItem({ key: 'home', destination: '/home' }),
+            validNavItem({
+              key: 'search',
+              destination: '/search',
+              i18n: 'nav.search',
+              icon: 'search',
+              group: { authenticated: false, i18n: 'nav.group.main' },
+            }),
+          ],
+        }),
+    };
+    const experiment = new ExperimentStub();
+    const { logger } = createMockLogger();
+    const service = new ConfigService(
+      repository as unknown as ConfigRepository,
+      experiment as unknown as ExperimentService,
+      logger,
+    );
+
+    const result = await service.getConfig();
+    assertEquals(result.id, '507f1f77bcf86cd799439011');
+    assertEquals(result.navigation.length, 2);
+    assertEquals(result.navigation[0].key, 'home');
+    assertEquals(result.navigation[1].key, 'search');
+  });
+
+  it('throws Error when navigation has duplicate keys', async () => {
+    const repository = {
+      getConfig: async () =>
+        makeDocumentStub({
+          navigation: [
+            validNavItem({ key: 'home', destination: '/home' }),
+            validNavItem({
+              key: 'home',
+              destination: '/home-alt',
+              i18n: 'nav.home',
+              icon: 'home',
+              group: { authenticated: false, i18n: 'nav.group.main' },
+            }),
+          ],
+        }),
+    };
+    const experiment = new ExperimentStub();
+    const { logger } = createMockLogger();
+    const service = new ConfigService(
+      repository as unknown as ConfigRepository,
+      experiment as unknown as ExperimentService,
+      logger,
+    );
+
+    await assertRejects(
+      () => service.getConfig(),
+      Error,
+      'Config navigation payload is invalid: Duplicate navigation key: "home"',
+    );
+  });
+
+  it('throws NotFoundException when repository returns null', async () => {
+    const repository = {
+      getConfig: async () => null,
+    };
+    const experiment = new ExperimentStub();
+    const { logger } = createMockLogger();
+    const service = new ConfigService(
+      repository as unknown as ConfigRepository,
+      experiment as unknown as ExperimentService,
+      logger,
+    );
+
+    await assertRejects(
+      () => service.getConfig(),
+      NotFoundException,
+    );
+  });
+});

--- a/src/package/config/config.service.ts
+++ b/src/package/config/config.service.ts
@@ -3,6 +3,7 @@ import { ExperimentService, PlatformSource } from '@scope/experiment';
 import { ConfigRepository } from './config.repository.ts';
 import { Config } from './config.types.ts';
 import { transform } from './config.transformer.ts';
+import { validateNavigation } from './config.validation.ts';
 import { LoggerService } from '@scope/logger';
 
 @Injectable()
@@ -29,6 +30,21 @@ export class ConfigService {
       this.logger.instance.error('No config document found in database');
       throw new NotFoundException();
     }
-    return transform({ document, ...features });
+    const config = transform({ document, ...features });
+
+    const navErrors = validateNavigation(config.navigation);
+    if (navErrors.length > 0) {
+      this.logger.instance.error(
+        'Config navigation payload validation failed',
+        { errors: navErrors },
+      );
+      throw new Error(
+        `Config navigation payload is invalid: ${
+          navErrors.map((e) => e.message).join('; ')
+        }`,
+      );
+    }
+
+    return config;
   }
 }

--- a/src/package/config/config.transformer.ts
+++ b/src/package/config/config.transformer.ts
@@ -10,6 +10,14 @@ const toImageUrl = (image: string, source: PlatformSource): string => {
   return image;
 };
 
+/**
+ * Derive a stable navigation key from a destination path.
+ * Strips leading slashes and replaces path separators with hyphens.
+ * Example: "/forum/recent" → "forum-recent"
+ */
+const keyFromDestination = (destination: string): string =>
+  destination.replace(/^\/+/, '').replace(/\//g, '-') || 'unknown';
+
 export const transform: Transform<
   {
     document: ConfigDocument;
@@ -34,6 +42,9 @@ export const transform: Transform<
       info: toImageUrl(image.info, platformSource),
       default: toImageUrl(image.default, platformSource),
     },
-    navigation: navigation,
+    navigation: navigation.map((item) => ({
+      ...item,
+      key: item.key || keyFromDestination(item.destination),
+    })),
   };
 };

--- a/src/package/config/config.validation.ts
+++ b/src/package/config/config.validation.ts
@@ -1,0 +1,110 @@
+/**
+ * Configuration payload validation for navigation entries.
+ *
+ * These guards run on the transformed config before the response is
+ * returned. They catch duplicate, malformed, or unstable navigation
+ * payloads at the source so downstream consumers (edge-graphql,
+ * anitrend-v2) never receive invalid data.
+ */
+
+import type { Config } from './config.types.ts';
+
+/** Structured validation failure for a navigation payload. */
+export interface NavigationValidationError {
+  /** Human-readable description of the problem. */
+  message: string;
+  /** The field or entry key associated with the error, if known. */
+  field?: string;
+}
+
+/**
+ * Validate the navigation array produced by the config transformer.
+ *
+ * Returns an empty array when the payload is safe to serve.
+ * Returns a non-empty array of errors when the payload must be
+ * rejected.
+ *
+ * Order of checks:
+ *   1. Required field presence (key, destination, i18n, icon, group.i18n)
+ *   2. Key uniqueness
+ *   3. Destination uniqueness (no allowlist needed for current entries;
+ *      destinations are expected to be unique)
+ */
+export function validateNavigation(
+  navigation: Config['navigation'],
+): NavigationValidationError[] {
+  const errors: NavigationValidationError[] = [];
+
+  if (!navigation || navigation.length === 0) {
+    errors.push({
+      message: 'Config navigation array is empty or missing',
+    });
+    return errors;
+  }
+
+  for (let i = 0; i < navigation.length; i++) {
+    const item = navigation[i];
+    const prefix = `navigation[${i}]`;
+
+    if (!item.key || item.key.length === 0) {
+      errors.push({
+        message: `${prefix}.key is empty or missing`,
+        field: `${prefix}.key`,
+      });
+    }
+
+    if (!item.destination || item.destination.length === 0) {
+      errors.push({
+        message: `${prefix}.destination is empty or missing`,
+        field: `${prefix}.destination`,
+      });
+    }
+
+    if (!item.i18n || item.i18n.length === 0) {
+      errors.push({
+        message: `${prefix}.i18n is empty or missing`,
+        field: `${prefix}.i18n`,
+      });
+    }
+
+    if (!item.icon || item.icon.length === 0) {
+      errors.push({
+        message: `${prefix}.icon is empty or missing`,
+        field: `${prefix}.icon`,
+      });
+    }
+
+    if (!item.group?.i18n || item.group.i18n.length === 0) {
+      errors.push({
+        message: `${prefix}.group.i18n is empty or missing`,
+        field: `${prefix}.group.i18n`,
+      });
+    }
+  }
+
+  // Duplicate key check — keys are the stable identity for persistence
+  const keySet = new Set<string>();
+  for (const item of navigation) {
+    if (item.key && keySet.has(item.key)) {
+      errors.push({
+        message: `Duplicate navigation key: "${item.key}"`,
+        field: 'key',
+      });
+    }
+    if (item.key) keySet.add(item.key);
+  }
+
+  // Duplicate destination check — destinations should be unique per entry
+  const destSet = new Set<string>();
+  for (const item of navigation) {
+    if (item.destination && destSet.has(item.destination)) {
+      errors.push({
+        message: `Duplicate navigation destination: "${item.destination}"`,
+        field: 'destination',
+      });
+    }
+    if (item.destination) destSet.add(item.destination);
+  }
+
+  return errors;
+}


### PR DESCRIPTION
## Description

Adds stable identity keys and backend payload validation for config navigation entries, fixing two companion issues.

### #386 - Stable identities
- Adds a `key` field to every navigation item in the runtime schema and public OpenAPI contract
- Transformer auto-generates keys from `destination` when absent in MongoDB (e.g. `/home` → `home`, `/anime/list` → `anime-list`)
- Explicit authored keys in MongoDB override auto-generation

### #387 - Payload integrity
- New `validateNavigation()` function rejects invalid payloads before serving
- Checks: missing required fields, duplicate keys, duplicate destinations
- Fails closed — invalid config throws an `Error` with structured validation messages, never silently served

### Files changed
| File | Change |
|---|---|
| `config.schema.ts` | Added `key: z.string().min(1)` to navigation schema |
| `config.contract.ts` | Added `key` to public OpenAPI contract |
| `config.document.ts` | Widened document type to accept optional key |
| `config.transformer.ts` | Generated keys from destinations when absent |
| `config.validation.ts` | New — validation with duplicate/field checks |
| `config.service.ts` | Calls validation before serving config |
| `config.service.test.ts` | New — 15 tests, all passing |

### Quality gates
- `deno fmt` ✅
- `deno lint` ✅
- `deno check` ✅
- `deno test` ✅ (66 passed, 0 failed)

Closes #386, Closes #387