### PR TITLE
fix(push): wire body schemas, add delivery persistence, retry, and TTL fixes

### DIFF
--- a/.github/swagger-spec.json
+++ b/.github/swagger-spec.json
@@ -1,0 +1,2630 @@
+{
+  "components": {
+    "schemas": {
+      "Character": {
+        "description": "Fictional character metadata resolved from Jikan (MAL), including media and voice-actor relations",
+        "properties": {
+          "about": {
+            "nullable": true,
+            "type": "string"
+          },
+          "anime": {
+            "default": [],
+            "items": {
+              "description": "Media entity related to a character",
+              "properties": {
+                "imageUrl": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "malId": {
+                  "exclusiveMinimum": 0,
+                  "type": "integer"
+                },
+                "role": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "malId",
+                "title",
+                "url"
+              ],
+              "title": "CharacterMediaRelation",
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "expiresAt": {
+            "type": "number"
+          },
+          "favorites": {
+            "default": 0,
+            "type": "number"
+          },
+          "fetchedAt": {
+            "type": "number"
+          },
+          "imageUrl": {
+            "nullable": true,
+            "type": "string"
+          },
+          "malId": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "manga": {
+            "default": [],
+            "items": {
+              "description": "Media entity related to a character",
+              "properties": {
+                "imageUrl": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "malId": {
+                  "exclusiveMinimum": 0,
+                  "type": "integer"
+                },
+                "role": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "malId",
+                "title",
+                "url"
+              ],
+              "title": "CharacterMediaRelation",
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nameKanji": {
+            "nullable": true,
+            "type": "string"
+          },
+          "nicknames": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "voices": {
+            "default": [],
+            "items": {
+              "description": "Voice actor relation for a character",
+              "properties": {
+                "imageUrl": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "language": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "malId": {
+                  "exclusiveMinimum": 0,
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "malId",
+                "name",
+                "url"
+              ],
+              "title": "CharacterVoiceRelation",
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "malId",
+          "name",
+          "fetchedAt",
+          "expiresAt"
+        ],
+        "title": "Character",
+        "type": "object"
+      },
+      "CharacterQuery": {
+        "description": "Query parameters for character lookup",
+        "properties": {
+          "malId": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "title": "CharacterQuery",
+        "type": "object"
+      },
+      "Config": {
+        "description": "Client configuration",
+        "properties": {
+          "genres": {
+            "default": [],
+            "items": {
+              "description": "Genre entry linked to a media entity",
+              "properties": {
+                "mediaId": {
+                  "minimum": 1,
+                  "type": "number"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "mediaId"
+              ],
+              "title": "ConfigGenre",
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/components/schemas/ConfigImage"
+          },
+          "navigation": {
+            "default": [],
+            "items": {
+              "description": "A single navigation entry",
+              "properties": {
+                "criteria": {
+                  "type": "string"
+                },
+                "destination": {
+                  "type": "string"
+                },
+                "group": {
+                  "description": "Navigation item group classification",
+                  "properties": {
+                    "authenticated": {
+                      "type": "boolean"
+                    },
+                    "i18n": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "authenticated",
+                    "i18n"
+                  ],
+                  "title": "ConfigNavigationGroup",
+                  "type": "object"
+                },
+                "i18n": {
+                  "type": "string"
+                },
+                "icon": {
+                  "type": "string"
+                },
+                "key": {
+                  "description": "Stable identity for persistence, dedupe, and diffing. Must not change unless a deliberate migration is intended.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "criteria",
+                "destination",
+                "i18n",
+                "icon",
+                "group"
+              ],
+              "title": "ConfigNavigationItem",
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/ConfigSettings"
+          }
+        },
+        "required": [
+          "id",
+          "settings",
+          "image"
+        ],
+        "title": "Config",
+        "type": "object"
+      },
+      "ConfigImage": {
+        "description": "Image URL configuration for the client",
+        "properties": {
+          "banner": {
+            "format": "uri",
+            "type": "string"
+          },
+          "default": {
+            "format": "uri",
+            "type": "string"
+          },
+          "error": {
+            "format": "uri",
+            "type": "string"
+          },
+          "info": {
+            "format": "uri",
+            "type": "string"
+          },
+          "loading": {
+            "format": "uri",
+            "type": "string"
+          },
+          "poster": {
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "banner",
+          "poster",
+          "loading",
+          "error",
+          "info",
+          "default"
+        ],
+        "title": "ConfigImage",
+        "type": "object"
+      },
+      "ConfigSettings": {
+        "description": "Application settings configuration",
+        "properties": {
+          "analyticsEnabled": {
+            "type": "boolean"
+          },
+          "platformSource": {
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "analyticsEnabled"
+        ],
+        "title": "ConfigSettings",
+        "type": "object"
+      },
+      "EpisodeQuery": {
+        "description": "Query parameters for episode listing",
+        "properties": {
+          "after": {
+            "type": "string"
+          },
+          "before": {
+            "type": "string"
+          },
+          "end": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "includeOrphans": {
+            "type": "boolean"
+          },
+          "kind": {
+            "enum": [
+              "main",
+              "ova",
+              "ona",
+              "recap",
+              "filler",
+              "special"
+            ],
+            "type": "string"
+          },
+          "limit": {
+            "default": 25,
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "malId": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "specialsOnly": {
+            "type": "boolean"
+          },
+          "start": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "malId"
+        ],
+        "title": "EpisodeQuery",
+        "type": "object"
+      },
+      "Episodes": {
+        "description": "Paginated episode listing with cursor navigation",
+        "properties": {
+          "count": {
+            "type": "number"
+          },
+          "data": {
+            "items": {
+              "description": "Canonical episode data from multiple sources",
+              "properties": {
+                "absoluteEpisodeNumber": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "aired": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "airedAfterEpisodeNumber": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "airedAfterSeasonNumber": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "airedBeforeEpisodeNumber": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "airedBeforeSeasonNumber": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "duration": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "episodeNumber": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "id": {
+                  "type": "number"
+                },
+                "image": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Episode type classification",
+                  "enum": [
+                    "main",
+                    "ova",
+                    "ona",
+                    "recap",
+                    "filler",
+                    "special"
+                  ],
+                  "example": "main",
+                  "nullable": true,
+                  "title": "EpisodeKind",
+                  "type": "string"
+                },
+                "number": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "poster": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "score": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "seasonNumber": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "synopsis": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "themes": {
+                  "default": {
+                    "endings": [],
+                    "openings": []
+                  },
+                  "description": "Opening and ending theme songs",
+                  "properties": {
+                    "endings": {
+                      "default": [],
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "openings": {
+                      "default": [],
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "title": "EpisodeThemes",
+                  "type": "object"
+                },
+                "title": {
+                  "description": "Multi-language episode title",
+                  "nullable": true,
+                  "properties": {
+                    "english": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "native": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "romanji": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "title": "EpisodeTitle",
+                  "type": "object"
+                },
+                "tmdbId": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "tvdbId": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "tvdbShowId": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "url": {
+                  "nullable": true,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id"
+              ],
+              "title": "Episode",
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "first": {
+            "nullable": true,
+            "type": "string"
+          },
+          "last": {
+            "nullable": true,
+            "type": "string"
+          },
+          "total": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "data",
+          "count",
+          "total"
+        ],
+        "title": "Episodes",
+        "type": "object"
+      },
+      "News": {
+        "description": "Schema representing a news document.",
+        "properties": {
+          "area": {
+            "nullable": true,
+            "type": "string"
+          },
+          "category": {
+            "nullable": true,
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "genre": {
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "image": {
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
+          },
+          "lang": {
+            "nullable": true,
+            "type": "string"
+          },
+          "link": {
+            "format": "uri",
+            "type": "string"
+          },
+          "publishedOn": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "link",
+          "description",
+          "content",
+          "publishedOn"
+        ],
+        "title": "News",
+        "type": "object"
+      },
+      "NewsConnection": {
+        "description": "Cursor-paged News connection",
+        "properties": {
+          "count": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "data": {
+            "items": {
+              "description": "Schema representing a news document.",
+              "properties": {
+                "area": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "category": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "content": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "genre": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "image": {
+                  "format": "uri",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "lang": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "link": {
+                  "format": "uri",
+                  "type": "string"
+                },
+                "publishedOn": {
+                  "type": "number"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "title",
+                "link",
+                "description",
+                "content",
+                "publishedOn"
+              ],
+              "title": "News",
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "first": {
+            "nullable": true,
+            "type": "string"
+          },
+          "last": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "count",
+          "data"
+        ],
+        "title": "NewsConnection",
+        "type": "object"
+      },
+      "NewsPagingQuery": {
+        "description": "Query parameters for paged news listing",
+        "properties": {
+          "after": {
+            "type": "string"
+          },
+          "before": {
+            "type": "string"
+          },
+          "limit": {
+            "default": 15,
+            "minimum": 1,
+            "type": "number"
+          }
+        },
+        "title": "NewsPagingQuery",
+        "type": "object"
+      },
+      "NewsQuery": {
+        "additionalProperties": false,
+        "description": "Query parameters for news feed",
+        "properties": {
+          "locale": {
+            "default": "en-US",
+            "description": "Locale for the news feed, e.g., en-GB, de-DE, fr-FR.",
+            "maxLength": 5,
+            "minLength": 5,
+            "type": "string"
+          }
+        },
+        "title": "NewsQuery",
+        "type": "object"
+      },
+      "PeopleQuery": {
+        "description": "Query parameters for people lookup",
+        "properties": {
+          "malId": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "title": "PeopleQuery",
+        "type": "object"
+      },
+      "Person": {
+        "description": "Anime staff or voice actor metadata resolved from Jikan (MAL)",
+        "properties": {
+          "about": {
+            "nullable": true,
+            "type": "string"
+          },
+          "alternateNames": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "birthday": {
+            "nullable": true,
+            "type": "number"
+          },
+          "expiresAt": {
+            "type": "number"
+          },
+          "familyName": {
+            "nullable": true,
+            "type": "string"
+          },
+          "favorites": {
+            "default": 0,
+            "type": "number"
+          },
+          "fetchedAt": {
+            "type": "number"
+          },
+          "givenName": {
+            "nullable": true,
+            "type": "string"
+          },
+          "imageUrl": {
+            "nullable": true,
+            "type": "string"
+          },
+          "malId": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "websiteUrl": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "malId",
+          "name",
+          "fetchedAt",
+          "expiresAt"
+        ],
+        "title": "Person",
+        "type": "object"
+      },
+      "PushAcknowledgment": {
+        "description": "Acknowledgment response for mutation operations",
+        "properties": {
+          "installationId": {
+            "description": "Installation identifier",
+            "type": "string"
+          },
+          "instance": {
+            "description": "UnifiedPush instance identifier",
+            "type": "string"
+          }
+        },
+        "required": [
+          "installationId",
+          "instance"
+        ],
+        "title": "PushAcknowledgment",
+        "type": "object"
+      },
+      "PushConfirmBody": {
+        "description": "Challenge confirmation request body",
+        "properties": {
+          "instance": {
+            "default": "default",
+            "minLength": 1,
+            "type": "string"
+          },
+          "token": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "token"
+        ],
+        "title": "PushConfirmBody",
+        "type": "object"
+      },
+      "PushDeleteBody": {
+        "description": "Installation deletion request body",
+        "properties": {
+          "instance": {
+            "default": "default",
+            "minLength": 1,
+            "type": "string"
+          },
+          "reason": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "title": "PushDeleteBody",
+        "type": "object"
+      },
+      "PushInstallation": {
+        "description": "Push installation registration state",
+        "properties": {
+          "installationId": {
+            "description": "Stable client-generated installation identifier",
+            "type": "string"
+          },
+          "instance": {
+            "description": "UnifiedPush instance identifier",
+            "type": "string"
+          },
+          "status": {
+            "description": "Lifecycle status of a push installation",
+            "enum": [
+              "pending",
+              "active",
+              "disabled",
+              "expired",
+              "revoked"
+            ],
+            "title": "PushInstallationStatus",
+            "type": "string"
+          }
+        },
+        "required": [
+          "installationId",
+          "instance",
+          "status"
+        ],
+        "title": "PushInstallation",
+        "type": "object"
+      },
+      "PushPreferencesBody": {
+        "description": "Topic preferences update request body",
+        "properties": {
+          "instance": {
+            "default": "default",
+            "minLength": 1,
+            "type": "string"
+          },
+          "topics": {
+            "properties": {
+              "airing": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              },
+              "appAnnouncements": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              },
+              "mediaUpdates": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              },
+              "news": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              },
+              "sync": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "topics"
+        ],
+        "title": "PushPreferencesBody",
+        "type": "object"
+      },
+      "PushProfileBody": {
+        "description": "Profile update request body",
+        "properties": {
+          "app": {
+            "default": null,
+            "nullable": true,
+            "properties": {
+              "build": {
+                "default": null,
+                "nullable": true,
+                "type": "string"
+              },
+              "code": {
+                "default": null,
+                "minimum": 0,
+                "nullable": true,
+                "type": "integer"
+              },
+              "source": {
+                "default": null,
+                "nullable": true,
+                "type": "string"
+              },
+              "version": {
+                "default": null,
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "capabilities": {
+            "default": null,
+            "nullable": true,
+            "properties": {
+              "notificationRuntimePermission": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              },
+              "supportsRichNotifications": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              },
+              "supportsSilentSync": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              },
+              "unifiedPush": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "device": {
+            "default": null,
+            "nullable": true,
+            "properties": {
+              "manufacturer": {
+                "default": null,
+                "nullable": true,
+                "type": "string"
+              },
+              "model": {
+                "default": null,
+                "nullable": true,
+                "type": "string"
+              },
+              "platform": {
+                "default": null,
+                "enum": [
+                  "android"
+                ],
+                "nullable": true,
+                "type": "string"
+              },
+              "sdk": {
+                "default": null,
+                "minimum": 0,
+                "nullable": true,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "identity": {
+            "default": null,
+            "nullable": true,
+            "properties": {
+              "anilistUserId": {
+                "default": null,
+                "exclusiveMinimum": 0,
+                "nullable": true,
+                "type": "integer"
+              },
+              "provider": {
+                "default": null,
+                "enum": [
+                  "anilist"
+                ],
+                "nullable": true,
+                "type": "string"
+              },
+              "state": {
+                "default": null,
+                "enum": [
+                  "client-declared"
+                ],
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "instance": {
+            "default": "default",
+            "minLength": 1,
+            "type": "string"
+          },
+          "locale": {
+            "default": null,
+            "nullable": true,
+            "properties": {
+              "language": {
+                "default": null,
+                "nullable": true,
+                "type": "string"
+              },
+              "region": {
+                "default": null,
+                "nullable": true,
+                "type": "string"
+              },
+              "timezone": {
+                "default": null,
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "topics": {
+            "default": null,
+            "nullable": true,
+            "properties": {
+              "airing": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              },
+              "appAnnouncements": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              },
+              "mediaUpdates": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              },
+              "news": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              },
+              "sync": {
+                "default": null,
+                "nullable": true,
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "views": {
+            "default": null,
+            "nullable": true,
+            "properties": {
+              "lastSeen": {
+                "default": null,
+                "nullable": true,
+                "type": "string"
+              },
+              "lastSeenAt": {
+                "default": null,
+                "nullable": true,
+                "type": "number"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "title": "PushProfileBody",
+        "type": "object"
+      },
+      "PushRegistrationBody": {
+        "description": "Installation registration request body",
+        "properties": {
+          "appBuild": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "appCode": {
+            "default": null,
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "appVersion": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "distributor": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "endpoint": {
+            "format": "uri",
+            "type": "string"
+          },
+          "installationId": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "instance": {
+            "default": "default",
+            "minLength": 1,
+            "type": "string"
+          },
+          "keys": {
+            "properties": {
+              "auth": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "p256dh": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "p256dh",
+              "auth"
+            ],
+            "type": "object"
+          },
+          "locale": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "platform": {
+            "default": "android",
+            "enum": [
+              "android"
+            ],
+            "type": "string"
+          },
+          "timezone": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "topics": {
+            "default": [],
+            "items": {
+              "enum": [
+                "news",
+                "appAnnouncements",
+                "sync"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "installationId",
+          "endpoint",
+          "keys"
+        ],
+        "title": "PushRegistrationBody",
+        "type": "object"
+      },
+      "PushVapid": {
+        "description": "VAPID public key for Android Web Push subscription",
+        "properties": {
+          "applicationServerKey": {
+            "description": "Base64url-encoded VAPID public key for Web Push subscription",
+            "example": "BLbL...vFc",
+            "type": "string"
+          }
+        },
+        "required": [
+          "applicationServerKey"
+        ],
+        "title": "PushVapid",
+        "type": "object"
+      },
+      "Series": {
+        "description": "Aggregated media entity from multiple sources",
+        "properties": {
+          "ageRating": {
+            "nullable": true,
+            "type": "string"
+          },
+          "airedEpisodes": {
+            "nullable": true,
+            "type": "number"
+          },
+          "animethemes": {
+            "items": {
+              "description": "Opening or ending theme with entries and song metadata",
+              "properties": {
+                "animethemeentries": {
+                  "default": [],
+                  "items": {
+                    "description": "A single anime theme entry with version info and videos",
+                    "properties": {
+                      "episodes": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "number"
+                      },
+                      "notes": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "nsfw": {
+                        "type": "boolean"
+                      },
+                      "spoiler": {
+                        "type": "boolean"
+                      },
+                      "version": {
+                        "nullable": true,
+                        "type": "number"
+                      },
+                      "videos": {
+                        "default": [],
+                        "items": {
+                          "description": "Video resource for an anime theme entry",
+                          "properties": {
+                            "audio": {
+                              "description": "Audio resource for an anime theme",
+                              "nullable": true,
+                              "properties": {
+                                "id": {
+                                  "type": "number"
+                                },
+                                "link": {
+                                  "format": "uri",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "link"
+                              ],
+                              "title": "AnimeThemesAudio",
+                              "type": "object"
+                            },
+                            "id": {
+                              "type": "number"
+                            },
+                            "link": {
+                              "format": "uri",
+                              "type": "string"
+                            },
+                            "lyrics": {
+                              "type": "boolean"
+                            },
+                            "nc": {
+                              "type": "boolean"
+                            },
+                            "overlap": {
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "resolution": {
+                              "nullable": true,
+                              "type": "number"
+                            },
+                            "source": {
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "subbed": {
+                              "type": "boolean"
+                            },
+                            "tags": {
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "uncen": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "link",
+                            "nc",
+                            "subbed",
+                            "lyrics",
+                            "uncen"
+                          ],
+                          "title": "AnimeThemesVideo",
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "nsfw",
+                      "spoiler"
+                    ],
+                    "title": "AnimeThemesEntry",
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "id": {
+                  "type": "number"
+                },
+                "sequence": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "slug": {
+                  "type": "string"
+                },
+                "song": {
+                  "description": "Song metadata for an anime theme",
+                  "nullable": true,
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "title": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "title": "AnimeThemesSong",
+                  "type": "object"
+                },
+                "type": {
+                  "enum": [
+                    "OP",
+                    "ED"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "type",
+                "slug"
+              ],
+              "title": "AnimeThemes",
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "banner": {
+            "nullable": true,
+            "type": "string"
+          },
+          "broadcast": {
+            "nullable": true,
+            "type": "string"
+          },
+          "chapters": {
+            "nullable": true,
+            "type": "number"
+          },
+          "classification": {
+            "nullable": true,
+            "type": "string"
+          },
+          "cover": {
+            "$ref": "#/components/schemas/SeriesCoverImage"
+          },
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "duration": {
+            "nullable": true,
+            "type": "number"
+          },
+          "fanart": {
+            "nullable": true,
+            "type": "string"
+          },
+          "format": {
+            "enum": [
+              "TV",
+              "MOVIE",
+              "SPECIAL",
+              "OVA",
+              "ONA"
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "homepage": {
+            "nullable": true,
+            "type": "string"
+          },
+          "images": {
+            "items": {
+              "description": "Image metadata including dimensions and type",
+              "properties": {
+                "height": {
+                  "type": "number"
+                },
+                "locale": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "BACKDROP",
+                    "POSTER",
+                    "LOGO"
+                  ],
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "width": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "height",
+                "width",
+                "url",
+                "type"
+              ],
+              "title": "SeriesImageAttributes",
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "isAdult": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "kind": {
+            "enum": [
+              "ANIME",
+              "MANGA"
+            ],
+            "type": "string"
+          },
+          "mediaId": {
+            "$ref": "#/components/schemas/SeriesId"
+          },
+          "moreInfo": {
+            "nullable": true,
+            "type": "string"
+          },
+          "networks": {
+            "items": {
+              "description": "Network or streaming service associated with the series",
+              "properties": {
+                "category": {
+                  "enum": [
+                    "DISTRIBUTION",
+                    "PRODUCTION"
+                  ],
+                  "type": "string"
+                },
+                "id": {
+                  "type": "number"
+                },
+                "isPrimary": {
+                  "type": "boolean"
+                },
+                "logoPath": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "originCountry": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "isPrimary",
+                "name",
+                "originCountry",
+                "category"
+              ],
+              "title": "SeriesNetwork",
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "publishedFrom": {
+            "nullable": true,
+            "type": "number"
+          },
+          "publishedTo": {
+            "nullable": true,
+            "type": "number"
+          },
+          "schedule": {
+            "$ref": "#/components/schemas/SeriesSchedule"
+          },
+          "source": {
+            "enum": [
+              "ORIGINAL",
+              "MANGA",
+              "LIGHT_NOVEL",
+              "VISUAL_NOVEL",
+              "VIDEO_GAME",
+              "OTHER"
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "FINISHED",
+              "RELEASING",
+              "NOT_YET_RELEASED"
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "title": {
+            "$ref": "#/components/schemas/SeriesTitle"
+          },
+          "trailers": {
+            "items": {
+              "description": "Trailer resource link",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "site": {
+                  "type": "string"
+                },
+                "thumbnail": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "site"
+              ],
+              "title": "SeriesTrailer",
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "volumes": {
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "required": [
+          "kind",
+          "mediaId",
+          "cover",
+          "title",
+          "images",
+          "updatedAt",
+          "animethemes",
+          "trailers",
+          "networks"
+        ],
+        "title": "Series",
+        "type": "object"
+      },
+      "SeriesCoverImage": {
+        "description": "Cover image URLs at multiple sizes with dominant color",
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "extraLarge": {
+            "type": "string"
+          },
+          "large": {
+            "type": "string"
+          },
+          "medium": {
+            "type": "string"
+          }
+        },
+        "title": "SeriesCoverImage",
+        "type": "object"
+      },
+      "SeriesId": {
+        "description": "Provider identifiers for a media entity",
+        "properties": {
+          "anidb": {
+            "nullable": true,
+            "type": "number"
+          },
+          "anilist": {
+            "nullable": true,
+            "type": "number"
+          },
+          "animePlanet": {
+            "nullable": true,
+            "type": "string"
+          },
+          "anisearch": {
+            "nullable": true,
+            "type": "number"
+          },
+          "imdb": {
+            "nullable": true,
+            "type": "string"
+          },
+          "kitsu": {
+            "nullable": true,
+            "type": "number"
+          },
+          "livechart": {
+            "nullable": true,
+            "type": "number"
+          },
+          "myanimelist": {
+            "nullable": true,
+            "type": "number"
+          },
+          "notify": {
+            "nullable": true,
+            "type": "string"
+          },
+          "shoboi": {
+            "nullable": true,
+            "type": "number"
+          },
+          "slug": {
+            "nullable": true,
+            "type": "string"
+          },
+          "themoviedb": {
+            "nullable": true,
+            "type": "number"
+          },
+          "trakt": {
+            "nullable": true,
+            "type": "number"
+          },
+          "tvMazeId": {
+            "nullable": true,
+            "type": "number"
+          },
+          "tvdb": {
+            "nullable": true,
+            "type": "number"
+          },
+          "tvrage": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "title": "SeriesId",
+        "type": "object"
+      },
+      "SeriesQuery": {
+        "description": "Query parameters for series lookup",
+        "properties": {
+          "anilist": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "mal": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "notify": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "slug": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "tmdb": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "trakt": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "tvdb": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          }
+        },
+        "title": "SeriesQuery",
+        "type": "object"
+      },
+      "SeriesSchedule": {
+        "description": "Air date schedule for the series",
+        "nullable": true,
+        "properties": {
+          "firstAirDate": {
+            "nullable": true,
+            "type": "number"
+          },
+          "lastAirDate": {
+            "nullable": true,
+            "type": "number"
+          },
+          "lastAiredEpisode": {
+            "description": "A scheduled episode in the series",
+            "nullable": true,
+            "properties": {
+              "airDate": {
+                "nullable": true,
+                "type": "number"
+              },
+              "episodeNumber": {
+                "nullable": true,
+                "type": "number"
+              },
+              "id": {
+                "type": "number"
+              },
+              "image": {
+                "nullable": true,
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "overview": {
+                "nullable": true,
+                "type": "string"
+              },
+              "productionCode": {
+                "nullable": true,
+                "type": "string"
+              },
+              "runtime": {
+                "nullable": true,
+                "type": "number"
+              },
+              "seasonNumber": {
+                "nullable": true,
+                "type": "number"
+              },
+              "tmdbId": {
+                "nullable": true,
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ],
+            "title": "SeriesScheduleEpisode",
+            "type": "object"
+          },
+          "nextEpisodeToAir": {
+            "description": "A scheduled episode in the series",
+            "nullable": true,
+            "properties": {
+              "airDate": {
+                "nullable": true,
+                "type": "number"
+              },
+              "episodeNumber": {
+                "nullable": true,
+                "type": "number"
+              },
+              "id": {
+                "type": "number"
+              },
+              "image": {
+                "nullable": true,
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "overview": {
+                "nullable": true,
+                "type": "string"
+              },
+              "productionCode": {
+                "nullable": true,
+                "type": "string"
+              },
+              "runtime": {
+                "nullable": true,
+                "type": "number"
+              },
+              "seasonNumber": {
+                "nullable": true,
+                "type": "number"
+              },
+              "tmdbId": {
+                "nullable": true,
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ],
+            "title": "SeriesScheduleEpisode",
+            "type": "object"
+          }
+        },
+        "title": "SeriesSchedule",
+        "type": "object"
+      },
+      "SeriesTitle": {
+        "description": "Multi-language titles for a media entity",
+        "properties": {
+          "canonical": {
+            "nullable": true,
+            "type": "string"
+          },
+          "english": {
+            "nullable": true,
+            "type": "string"
+          },
+          "harigana": {
+            "nullable": true,
+            "type": "string"
+          },
+          "japanese": {
+            "nullable": true,
+            "type": "string"
+          },
+          "romaji": {
+            "nullable": true,
+            "type": "string"
+          },
+          "synonyms": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "title": "SeriesTitle",
+        "type": "object"
+      },
+      "Studio": {
+        "description": "Animation studio metadata resolved from Jikan (MAL)",
+        "properties": {
+          "about": {
+            "nullable": true,
+            "type": "string"
+          },
+          "animeCount": {
+            "default": 0,
+            "type": "number"
+          },
+          "established": {
+            "nullable": true,
+            "type": "number"
+          },
+          "expiresAt": {
+            "type": "number"
+          },
+          "favorites": {
+            "default": 0,
+            "type": "number"
+          },
+          "fetchedAt": {
+            "type": "number"
+          },
+          "imageUrl": {
+            "nullable": true,
+            "type": "string"
+          },
+          "malId": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "titles": {
+            "default": [],
+            "items": {
+              "description": "Studio alternate title",
+              "properties": {
+                "title": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "type": {
+                  "nullable": true,
+                  "type": "string"
+                }
+              },
+              "title": "StudioTitle",
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "malId",
+          "name",
+          "fetchedAt",
+          "expiresAt"
+        ],
+        "title": "Studio",
+        "type": "object"
+      },
+      "StudioQuery": {
+        "description": "Query parameters for studio lookup",
+        "properties": {
+          "malId": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "title": "StudioQuery",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "description": "The edge API",
+    "title": "Edge API",
+    "version": "1.0"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/v1": {
+      "get": {
+        "operationId": "index",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/characters": {
+      "get": {
+        "operationId": "character",
+        "parameters": [
+          {
+            "description": "",
+            "in": "query",
+            "name": "malId",
+            "schema": {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Character"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/config": {
+      "get": {
+        "operationId": "config",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Config"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/episodes": {
+      "get": {
+        "operationId": "episodes",
+        "parameters": [
+          {
+            "description": "",
+            "in": "query",
+            "name": "malId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "after",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "before",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "main",
+                "ova",
+                "ona",
+                "recap",
+                "filler",
+                "special"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "specialsOnly",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "start",
+            "required": false,
+            "schema": {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "end",
+            "required": false,
+            "schema": {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "includeOrphans",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Episodes"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/news": {
+      "get": {
+        "operationId": "news",
+        "parameters": [
+          {
+            "description": "",
+            "in": "query",
+            "name": "before",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 15,
+              "minimum": 1,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NewsConnection"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/news/feed": {
+      "get": {
+        "operationId": "newsFeed",
+        "parameters": [
+          {
+            "description": "",
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "default": "en-US",
+              "description": "Locale for the news feed, e.g., en-GB, de-DE, fr-FR.",
+              "maxLength": 5,
+              "minLength": 5,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/News"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/people": {
+      "get": {
+        "operationId": "person",
+        "parameters": [
+          {
+            "description": "",
+            "in": "query",
+            "name": "malId",
+            "schema": {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Person"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/push/installations": {
+      "post": {
+        "operationId": "registerInstallation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushRegistrationBody"
+              }
+            }
+          },
+          "description": "",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushInstallation"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/push/installations/{installationId}": {
+      "delete": {
+        "operationId": "deleteInstallation",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "installationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushDeleteBody"
+              }
+            }
+          },
+          "description": "",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushAcknowledgment"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/push/installations/{installationId}/confirm": {
+      "post": {
+        "operationId": "confirmInstallation",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "installationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushConfirmBody"
+              }
+            }
+          },
+          "description": "",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushInstallation"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/push/installations/{installationId}/preferences": {
+      "patch": {
+        "operationId": "updatePreferences",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "installationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushPreferencesBody"
+              }
+            }
+          },
+          "description": "",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushAcknowledgment"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/push/installations/{installationId}/profile": {
+      "put": {
+        "operationId": "updateProfile",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "installationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushProfileBody"
+              }
+            }
+          },
+          "description": "",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushAcknowledgment"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/push/installations/{installationId}/test": {
+      "post": {
+        "operationId": "sendTestPush",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "installationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushAcknowledgment"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/push/vapid": {
+      "get": {
+        "operationId": "vapid",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushVapid"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/series": {
+      "get": {
+        "operationId": "series",
+        "parameters": [
+          {
+            "description": "",
+            "in": "query",
+            "name": "trakt",
+            "schema": {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "slug",
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "tvdb",
+            "schema": {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "tmdb",
+            "schema": {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "notify",
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "anilist",
+            "schema": {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "mal",
+            "schema": {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Series"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/studios": {
+      "get": {
+        "operationId": "studio",
+        "parameters": [
+          {
+            "description": "",
+            "in": "query",
+            "name": "malId",
+            "schema": {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Studio"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "servers": [],
+  "tags": []
+}

--- a/src/common/openapi/guard.test.ts
+++ b/src/common/openapi/guard.test.ts
@@ -31,6 +31,11 @@ function makeValidDoc(
     'PushVapid',
     'PushInstallation',
     'PushAcknowledgment',
+    'PushRegistrationBody',
+    'PushConfirmBody',
+    'PushProfileBody',
+    'PushPreferencesBody',
+    'PushDeleteBody',
   ];
   for (const name of expectedNames) {
     schemas[name] = { type: 'object', properties: {} };
@@ -136,12 +141,26 @@ function makeValidDoc(
       '/v1/push/installations': {
         post: {
           operationId: 'registerInstallation',
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/PushRegistrationBody' },
+              },
+            },
+          },
           responses: {},
         },
       },
       '/v1/push/installations/:installationId/confirm': {
         post: {
           operationId: 'confirmInstallation',
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/PushConfirmBody' },
+              },
+            },
+          },
           responses: {
             200: {
               description: 'OK',
@@ -157,6 +176,13 @@ function makeValidDoc(
       '/v1/push/installations/:installationId/profile': {
         put: {
           operationId: 'updateProfile',
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/PushProfileBody' },
+              },
+            },
+          },
           responses: {
             200: {
               description: 'OK',
@@ -172,6 +198,13 @@ function makeValidDoc(
       '/v1/push/installations/:installationId/preferences': {
         patch: {
           operationId: 'updatePreferences',
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/PushPreferencesBody' },
+              },
+            },
+          },
           responses: {
             200: {
               description: 'OK',
@@ -187,6 +220,13 @@ function makeValidDoc(
       '/v1/push/installations/:installationId': {
         delete: {
           operationId: 'deleteInstallation',
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/PushDeleteBody' },
+              },
+            },
+          },
           responses: {
             200: {
               description: 'OK',

--- a/src/common/openapi/names.ts
+++ b/src/common/openapi/names.ts
@@ -49,6 +49,11 @@ export const EXPECTED_SCHEMA_NAMES = [
   'PushVapid',
   'PushInstallation',
   'PushAcknowledgment',
+  'PushRegistrationBody',
+  'PushConfirmBody',
+  'PushProfileBody',
+  'PushPreferencesBody',
+  'PushDeleteBody',
 ] as const;
 
 /**

--- a/src/database/index.service.ts
+++ b/src/database/index.service.ts
@@ -113,12 +113,6 @@ export class DatabaseIndexService implements OnAppBootstrap {
         { expireAfterSeconds: 7776000, name: 'idx_attempted_ttl' },
       );
 
-      // Index on delivery status
-      await collection.createIndex(
-        { status: 1 },
-        { name: 'idx_delivery_status' },
-      );
-
       this.logger.instance.debug(
         `Created indexes on ${PUSH_DELIVERY_ATTEMPTS}`,
       );

--- a/src/database/testing/memory-collection.ts
+++ b/src/database/testing/memory-collection.ts
@@ -137,6 +137,9 @@ export class InMemoryCollection<T extends Document> implements Collection<T> {
         } else if (typeof aVal === 'string' && typeof bVal === 'string') {
           if (aVal < bVal) return ascending ? -1 : 1;
           if (aVal > bVal) return ascending ? 1 : -1;
+        } else if (aVal instanceof Date && bVal instanceof Date) {
+          if (aVal.getTime() < bVal.getTime()) return ascending ? -1 : 1;
+          if (aVal.getTime() > bVal.getTime()) return ascending ? 1 : -1;
         }
       }
       return 0;

--- a/src/package/push/push-delivery-attempt.repository.test.ts
+++ b/src/package/push/push-delivery-attempt.repository.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, it } from '@std/testing/bdd';
+import { assertEquals, assertExists } from '@std/assert';
+import { createMockLogger } from '@scope/common/testing';
+import { type MongoService } from '@scope/database';
+import { InMemoryCollection } from '@scope/database/testing';
+import type {
+  BulkWriteOptions,
+  Filter,
+  FindOptions,
+  InsertManyResult,
+  OptionalUnlessRequiredId,
+} from 'mongodb';
+import {
+  type PushDeliveryAttemptDocument,
+  PushDeliveryAttemptRepository,
+} from './push-delivery-attempt.repository.ts';
+
+// --- Mock wrappers ---
+
+class MockMongoCollection {
+  constructor(
+    private readonly memoryCollection: InMemoryCollection<
+      PushDeliveryAttemptDocument
+    >,
+  ) {}
+
+  find(
+    filter: Filter<PushDeliveryAttemptDocument>,
+    options?: FindOptions<PushDeliveryAttemptDocument>,
+  ) {
+    return {
+      toArray: () => this.memoryCollection.find(filter, options),
+    };
+  }
+
+  insertMany(
+    docs: ReadonlyArray<OptionalUnlessRequiredId<PushDeliveryAttemptDocument>>,
+    options?: BulkWriteOptions,
+  ): Promise<InsertManyResult<PushDeliveryAttemptDocument>> {
+    return this.memoryCollection.insertMany(docs, options);
+  }
+}
+
+class MockMongoService {
+  constructor(private readonly memoryCollection: MockMongoCollection) {}
+
+  collection<T>(_name: string): MockMongoCollection {
+    return this.memoryCollection as unknown as MockMongoCollection & T;
+  }
+}
+
+// --- Test helper ---
+
+const createDeliveryDoc = (
+  overrides: Partial<PushDeliveryAttemptDocument> = {},
+): PushDeliveryAttemptDocument => ({
+  installationId: 'test-install-1',
+  instance: 'default',
+  endpointHash: 'sha256hash',
+  type: 'push.test',
+  id: 'msg-1',
+  success: true,
+  gone: false,
+  latencyMs: 100,
+  attemptedAt: new Date('2026-01-01T00:00:00Z'),
+  ...overrides,
+});
+
+// --- Tests ---
+
+describe('PushDeliveryAttemptRepository', () => {
+  let collection: InMemoryCollection<PushDeliveryAttemptDocument>;
+  let logger: ReturnType<typeof createMockLogger>['logger'];
+
+  beforeEach(() => {
+    collection = new InMemoryCollection<PushDeliveryAttemptDocument>();
+    logger = createMockLogger().logger;
+  });
+
+  const createRepo = () =>
+    new PushDeliveryAttemptRepository(
+      new MockMongoService(
+        new MockMongoCollection(collection),
+      ) as unknown as MongoService,
+      logger,
+    );
+
+  describe('insert', () => {
+    it('persists a document that can be found by findByInstallation', async () => {
+      const repo = createRepo();
+      const doc = createDeliveryDoc({
+        installationId: 'inst-1',
+        id: 'msg-abc',
+      });
+
+      await repo.insert(doc);
+
+      const results = await repo.findByInstallation('inst-1');
+      assertEquals(results.length, 1);
+      assertExists(results[0]);
+      assertEquals(results[0].installationId, 'inst-1');
+      assertEquals(results[0].id, 'msg-abc');
+      assertEquals(results[0].success, true);
+      assertEquals(results[0].latencyMs, 100);
+      assertEquals(
+        results[0].attemptedAt.getTime(),
+        new Date('2026-01-01T00:00:00Z').getTime(),
+      );
+    });
+  });
+
+  describe('findByInstallation', () => {
+    it('returns documents sorted by attemptedAt descending', async () => {
+      const repo = createRepo();
+
+      await repo.insert(
+        createDeliveryDoc({
+          installationId: 'inst-2',
+          id: 'oldest',
+          attemptedAt: new Date('2026-01-01T00:00:00Z'),
+        }),
+      );
+      await repo.insert(
+        createDeliveryDoc({
+          installationId: 'inst-2',
+          id: 'middle',
+          attemptedAt: new Date('2026-01-02T00:00:00Z'),
+        }),
+      );
+      await repo.insert(
+        createDeliveryDoc({
+          installationId: 'inst-2',
+          id: 'newest',
+          attemptedAt: new Date('2026-01-03T00:00:00Z'),
+        }),
+      );
+
+      const results = await repo.findByInstallation('inst-2');
+
+      assertEquals(results.length, 3);
+      assertEquals(results[0].id, 'newest');
+      assertEquals(results[1].id, 'middle');
+      assertEquals(results[2].id, 'oldest');
+    });
+
+    it('respects the limit parameter', async () => {
+      const repo = createRepo();
+
+      for (let i = 0; i < 5; i++) {
+        await repo.insert(
+          createDeliveryDoc({
+            installationId: 'inst-3',
+            id: `msg-${i}`,
+            attemptedAt: new Date(`2026-01-0${i + 1}T00:00:00Z`),
+          }),
+        );
+      }
+
+      const results = await repo.findByInstallation('inst-3', 2);
+
+      assertEquals(results.length, 2);
+      // Most recent first (msg-4 has date 2026-01-05, msg-3 has 2026-01-04)
+      assertEquals(results[0].id, 'msg-4');
+      assertEquals(results[1].id, 'msg-3');
+    });
+
+    it('returns empty array for unknown installation', async () => {
+      const repo = createRepo();
+
+      await repo.insert(
+        createDeliveryDoc({
+          installationId: 'inst-known',
+          id: 'some-msg',
+        }),
+      );
+
+      const results = await repo.findByInstallation('nobody');
+      assertEquals(results, []);
+    });
+  });
+});

--- a/src/package/push/push-delivery-attempt.repository.ts
+++ b/src/package/push/push-delivery-attempt.repository.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@danet/core';
+import { MongoService } from '@scope/database';
+import { LoggerService } from '@scope/logger';
+import { Collection, MongoCollectionAdapter } from '@scope/database/collection';
+
+/**
+ * MongoDB document shape for push delivery attempts.
+ *
+ * Records every push notification delivery outcome for
+ * observability and debugging.
+ */
+export interface PushDeliveryAttemptDocument {
+  installationId: string;
+  instance: string;
+  endpointHash: string;
+  type: string;
+  id: string;
+  success: boolean;
+  gone: boolean;
+  statusCode?: number;
+  error?: string;
+  latencyMs: number;
+  attemptedAt: Date;
+}
+
+const COLLECTION_NAME = 'push_delivery_attempts';
+
+@Injectable()
+export class PushDeliveryAttemptRepository {
+  private readonly collection: Collection<PushDeliveryAttemptDocument>;
+
+  constructor(
+    private readonly mongo: MongoService,
+    private readonly logger: LoggerService,
+  ) {
+    this.collection = new MongoCollectionAdapter(
+      this.mongo.collection<PushDeliveryAttemptDocument>(COLLECTION_NAME),
+    );
+  }
+
+  /**
+   * Record a delivery attempt.
+   *
+   * Fire-and-forget: callers should not await this or
+   * throw on persistence failures.
+   */
+  async insert(doc: PushDeliveryAttemptDocument): Promise<void> {
+    await this.collection.insertMany([doc]);
+  }
+
+  /**
+   * Get recent delivery attempts for an installation.
+   *
+   * Useful for debugging and observability of push delivery.
+   */
+  async findByInstallation(
+    installationId: string,
+    limit = 20,
+  ): Promise<PushDeliveryAttemptDocument[]> {
+    const docs = await this.collection.find(
+      { installationId },
+      { sort: { attemptedAt: -1 }, limit },
+    );
+    return docs;
+  }
+}

--- a/src/package/push/push-retry.service.test.ts
+++ b/src/package/push/push-retry.service.test.ts
@@ -1,0 +1,146 @@
+import { describe, it } from '@std/testing/bdd';
+import { assertEquals } from '@std/assert';
+import { assertSpyCalls, spy } from '@std/testing/mock';
+import { createMockLogger, createMockSecret } from '@scope/common/testing';
+import { PushRetryService } from './push-retry.service.ts';
+import type { PushSenderService } from '@scope/service/push-sender';
+import type { PushRepository } from './push.repository.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockRedis() {
+  const store = new Map<string, string>();
+
+  return {
+    isConnected: true,
+    connect: spy(async () => {}),
+    ping: spy(async () => 'PONG'),
+    close: spy(() => {}),
+    hset: spy(async (_key: string, _field: string, _value: string) => 1),
+    hgetall: spy(async () => {
+      const result: Record<string, string> = {};
+      for (const [k, v] of store.entries()) result[k] = v;
+      return result;
+    }),
+    hdel: spy(async (_key: string, _field: string) => 1),
+  };
+}
+
+function createService(
+  deps: {
+    pushSender?: Partial<PushSenderService>;
+    pushRepo?: Partial<PushRepository>;
+    redisConnected?: boolean;
+  } = {},
+): PushRetryService {
+  const { service: secret } = createMockSecret({
+    REDIS_URL: 'redis://localhost:6379',
+    DENO_ENV: 'test',
+  });
+  const { service: logger } = createMockLogger();
+  const pushSender = (deps.pushSender ?? {}) as PushSenderService;
+  const pushRepo = (deps.pushRepo ?? {}) as PushRepository;
+
+  const service = new PushRetryService(
+    secret,
+    pushSender,
+    pushRepo,
+    logger,
+  );
+
+  // Override the redis client with our mock
+  if (deps.redisConnected !== false) {
+    const mockRedis = createMockRedis();
+    (service as unknown as { redis: typeof mockRedis }).redis = mockRedis;
+  }
+
+  return service;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PushRetryService', () => {
+  it('constructs without errors', () => {
+    const service = createService();
+    assertEquals(typeof service.enqueue, 'function');
+    assertEquals(typeof service.poll, 'function');
+  });
+
+  it('enqueue stores a job in Redis', async () => {
+    const mockRedis = createMockRedis();
+    const service = createService();
+    (service as unknown as { redis: typeof mockRedis }).redis = mockRedis;
+
+    await service.enqueue({
+      installationId: 'inst-1',
+      instance: 'default',
+      endpoint: 'https://push.test/fcm/endpoint',
+      keys: { p256dh: 'p256dh-test', auth: 'auth-test' },
+      payload: { type: 'push.test', id: 'msg-1' },
+      type: 'push.test',
+    });
+
+    assertSpyCalls(mockRedis.hset as never, 1);
+  });
+
+  it('enqueue skips when Redis is not connected', async () => {
+    const mockRedis = { ...createMockRedis(), isConnected: false };
+    const service = createService();
+    (service as unknown as { redis: typeof mockRedis }).redis = mockRedis;
+
+    await service.enqueue({
+      installationId: 'inst-1',
+      instance: 'default',
+      endpoint: 'https://push.test/fcm/endpoint',
+      keys: { p256dh: 'p256dh-test', auth: 'auth-test' },
+      payload: { type: 'push.test', id: 'msg-1' },
+      type: 'push.test',
+    });
+
+    assertSpyCalls(mockRedis.hset as never, 0);
+  });
+
+  it('poll skips when already polling', async () => {
+    const service = createService();
+    // Set polling to true to simulate concurrent poll
+    (service as unknown as { polling: boolean }).polling = true;
+
+    // Should return immediately without error
+    await service.poll();
+  });
+
+  it('poll skips jobs not yet due', async () => {
+    const mockRedis = createMockRedis();
+    const service = createService();
+    (service as unknown as { redis: typeof mockRedis }).redis = mockRedis;
+
+    // Store a job that's not due for another hour
+    const futureJob = JSON.stringify({
+      installationId: 'inst-1',
+      instance: 'default',
+      endpoint: 'https://push.test/fcm/endpoint',
+      keys: { p256dh: 'p256dh-test', auth: 'auth-test' },
+      payload: { type: 'push.test', id: 'msg-1' },
+      type: 'push.test',
+      attempt: 1,
+      nextRetryAt: Date.now() + 3_600_000,
+    });
+    const store = new Map<string, string>();
+    store.set('inst-1:default:push.test:msg-1', futureJob);
+    mockRedis.hgetall = spy(async () => {
+      const result: Record<string, string> = {};
+      for (const [k, v] of store.entries()) result[k] = v;
+      return result;
+    });
+    (service as unknown as { redis: typeof mockRedis }).redis = mockRedis;
+
+    await service.poll();
+
+    // Job should not be touched - no hdel, no send
+    assertSpyCalls(mockRedis.hdel as never, 0);
+  });
+});

--- a/src/package/push/push-retry.service.ts
+++ b/src/package/push/push-retry.service.ts
@@ -1,0 +1,155 @@
+import { Injectable, SCOPE } from '@danet/core';
+import { Interval } from '@danet/core';
+import { OnAppBootstrap, OnAppClose } from '@danet/core/hook';
+import { createLazyClient, type Redis } from '@db/redis';
+import { SecretService } from '@scope/secret';
+import { LoggerService } from '@scope/logger';
+import { PushSenderService } from '@scope/service/push-sender';
+import type { PushSubscription } from '@scope/service/push-sender';
+import { PushRepository } from './push.repository.ts';
+
+interface RetryJob {
+  installationId: string;
+  instance: string;
+  endpoint: string;
+  keys: PushSubscription['keys'];
+  payload: Record<string, unknown>;
+  type: string;
+  attempt: number; // 1-based retry count
+  nextRetryAt: number; // epoch ms
+}
+
+const RETRY_BACKOFF_MS = [0, 60_000, 300_000, 1_800_000]; // attempts 1-4
+const MAX_RETRIES = 4;
+const RETRY_POLL_INTERVAL_MS = 60_000; // poll every minute
+const REDIS_KEY = 'edge:push:retry';
+
+@Injectable({ scope: SCOPE.GLOBAL })
+export class PushRetryService implements OnAppBootstrap, OnAppClose {
+  private redis!: Redis;
+  private polling = false;
+
+  constructor(
+    secret: SecretService,
+    private readonly pushSender: PushSenderService,
+    private readonly pushRepo: PushRepository,
+    private readonly logger: LoggerService,
+  ) {
+    this.redis = this.createRedisClient(secret);
+  }
+
+  private createRedisClient(secret: SecretService): Redis {
+    const url = secret.get<string>('REDIS_URL');
+    const { hostname, port, username, password } = new URL(url);
+    const options: Parameters<typeof createLazyClient>[0] = {
+      hostname,
+      port: Number.parseInt(port, 10),
+    };
+
+    if (username.length > 0) {
+      options.username = username;
+    }
+    if (password.length > 0) {
+      options.password = password;
+    }
+
+    return createLazyClient(options);
+  }
+
+  /** Enqueue a retry job after a failed delivery. */
+  async enqueue(job: Omit<RetryJob, 'attempt' | 'nextRetryAt'>): Promise<void> {
+    if (!this.redis.isConnected) return;
+
+    const retryJob: RetryJob = {
+      ...job,
+      attempt: 1,
+      nextRetryAt: Date.now() + RETRY_BACKOFF_MS[0],
+    };
+
+    const jobId = `${job.installationId}:${job.instance}:${job.type}:${
+      (job.payload as { id: string }).id ?? '0'
+    }`;
+    await this.redis.hset(REDIS_KEY, jobId, JSON.stringify(retryJob));
+  }
+
+  /** Poll for due retry jobs and attempt delivery. Runs every minute. */
+  @Interval(RETRY_POLL_INTERVAL_MS)
+  async poll(): Promise<void> {
+    if (this.polling || !this.redis.isConnected) return;
+    this.polling = true;
+
+    try {
+      const jobs = await this.redis.hgetall(REDIS_KEY);
+      const now = Date.now();
+
+      for (const [jobId, raw] of Object.entries(jobs)) {
+        const job: RetryJob = JSON.parse(raw);
+        if (job.nextRetryAt > now) continue; // not due yet
+
+        try {
+          const subscriber = this.pushSender.subscribe({
+            endpoint: job.endpoint,
+            keys: job.keys,
+          });
+          const result = await this.pushSender.send(
+            subscriber,
+            job.endpoint,
+            job.payload as Parameters<PushSenderService['send']>[2],
+            job.installationId,
+          );
+
+          if (result.gone) {
+            await this.pushRepo.markExpired(
+              job.installationId,
+              job.instance,
+            );
+            await this.redis.hdel(REDIS_KEY, jobId);
+          } else if (result.success) {
+            await this.redis.hdel(REDIS_KEY, jobId);
+            this.logger.instance.debug(`Retry succeeded for ${jobId}`);
+          } else if (job.attempt < MAX_RETRIES) {
+            // Still failing — schedule next retry
+            const nextAttempt = job.attempt + 1;
+            job.attempt = nextAttempt;
+            job.nextRetryAt = now + RETRY_BACKOFF_MS[nextAttempt - 1];
+            await this.redis.hset(REDIS_KEY, jobId, JSON.stringify(job));
+          } else {
+            // Max retries reached — give up
+            await this.redis.hdel(REDIS_KEY, jobId);
+            this.logger.instance.warn(
+              `Retry exhausted for ${jobId} after ${MAX_RETRIES} attempts`,
+            );
+          }
+        } catch (error) {
+          this.logger.instance.warn(
+            `Retry attempt failed for ${jobId}`,
+            { cause: error },
+          );
+        }
+      }
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  async onAppBootstrap(): Promise<void> {
+    try {
+      await this.redis.connect();
+      const pong = await this.redis.ping();
+      this.logger.instance.debug(
+        `Push-retry Redis connection validated: ${pong}`,
+      );
+    } catch (err) {
+      this.logger.instance.warn(
+        'Push-retry Redis connection failed during bootstrap. Push retries will be unavailable until Redis is configured.',
+        { cause: err },
+      );
+    }
+  }
+
+  async onAppClose(): Promise<void> {
+    if (this.redis.isConnected) {
+      this.redis.close();
+    }
+  }
+}

--- a/src/package/push/push-retry.service.ts
+++ b/src/package/push/push-retry.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, SCOPE } from '@danet/core';
-import { Interval } from '@danet/core';
 import { OnAppBootstrap, OnAppClose } from '@danet/core/hook';
 import { createLazyClient, type Redis } from '@db/redis';
 import { SecretService } from '@scope/secret';
@@ -28,6 +27,7 @@ const REDIS_KEY = 'edge:push:retry';
 export class PushRetryService implements OnAppBootstrap, OnAppClose {
   private redis!: Redis;
   private polling = false;
+  private pollTimer: ReturnType<typeof setInterval> | undefined;
 
   constructor(
     secret: SecretService,
@@ -73,7 +73,6 @@ export class PushRetryService implements OnAppBootstrap, OnAppClose {
   }
 
   /** Poll for due retry jobs and attempt delivery. Runs every minute. */
-  @Interval(RETRY_POLL_INTERVAL_MS)
   async poll(): Promise<void> {
     if (this.polling || !this.redis.isConnected) return;
     this.polling = true;
@@ -139,6 +138,12 @@ export class PushRetryService implements OnAppBootstrap, OnAppClose {
       this.logger.instance.debug(
         `Push-retry Redis connection validated: ${pong}`,
       );
+      // Start polling interval (manual setInterval avoids
+      // ScheduleModule + @Interval crash during Swagger generation)
+      this.pollTimer = setInterval(
+        () => this.poll().catch(() => {}),
+        RETRY_POLL_INTERVAL_MS,
+      );
     } catch (err) {
       this.logger.instance.warn(
         'Push-retry Redis connection failed during bootstrap. Push retries will be unavailable until Redis is configured.',
@@ -148,6 +153,9 @@ export class PushRetryService implements OnAppBootstrap, OnAppClose {
   }
 
   async onAppClose(): Promise<void> {
+    if (this.pollTimer !== undefined) {
+      clearInterval(this.pollTimer);
+    }
     if (this.redis.isConnected) {
       this.redis.close();
     }

--- a/src/package/push/push.controller.ts
+++ b/src/package/push/push.controller.ts
@@ -1,5 +1,5 @@
 import {
-  Body,
+  Body as CoreBody,
   Controller,
   Delete,
   Get,
@@ -9,14 +9,20 @@ import {
   Put,
   UseGuard,
 } from '@danet/core';
+import { Body } from '@danet/zod';
 import { ReturnedSchema } from '@danet/zod';
 import { LoggerService } from '@scope/logger';
 import { RateLimitGuard } from '@scope/guard/rate-limit';
 import { PushService } from './push.service.ts';
 import {
   PushAcknowledgmentSwagger,
+  PushConfirmBodySwagger,
   PushConfirmSwagger,
+  PushDeleteBodySwagger,
   PushInstallationSwagger,
+  PushPreferencesBodySwagger,
+  PushProfileBodySwagger,
+  PushRegistrationBodySwagger,
   PushVapidSwagger,
 } from './push.swagger.ts';
 import type {
@@ -56,7 +62,8 @@ export class PushController {
   @Post('installations')
   @ReturnedSchema(PushInstallationSwagger)
   async registerInstallation(
-    @Body() registration: PushInstallationRegistration,
+    @Body(PushRegistrationBodySwagger) registration:
+      PushInstallationRegistration,
   ): Promise<{
     installationId: string;
     instance: string;
@@ -69,7 +76,7 @@ export class PushController {
   @ReturnedSchema(PushConfirmSwagger)
   async confirmInstallation(
     @Param('installationId') installationId: string,
-    @Body() confirmation: PushChallengeConfirm,
+    @Body(PushConfirmBodySwagger) confirmation: PushChallengeConfirm,
   ): Promise<{
     installationId: string;
     instance: string;
@@ -85,7 +92,7 @@ export class PushController {
   @ReturnedSchema(PushAcknowledgmentSwagger)
   async updateProfile(
     @Param('installationId') installationId: string,
-    @Body() profile: PushProfile,
+    @Body(PushProfileBodySwagger) profile: PushProfile,
   ): Promise<{ installationId: string; instance: string }> {
     await this.pushService.updateProfile(installationId, profile);
     return {
@@ -98,7 +105,7 @@ export class PushController {
   @ReturnedSchema(PushAcknowledgmentSwagger)
   async updatePreferences(
     @Param('installationId') installationId: string,
-    @Body() preferences: PushPreferences,
+    @Body(PushPreferencesBodySwagger) preferences: PushPreferences,
   ): Promise<{ installationId: string; instance: string }> {
     await this.pushService.updatePreferences(installationId, preferences);
     return {
@@ -111,7 +118,7 @@ export class PushController {
   @ReturnedSchema(PushAcknowledgmentSwagger)
   async deleteInstallation(
     @Param('installationId') installationId: string,
-    @Body() deletion: PushDelete,
+    @Body(PushDeleteBodySwagger) deletion: PushDelete,
   ): Promise<{ installationId: string; instance: string }> {
     await this.pushService.deleteInstallation(installationId, deletion);
     return {
@@ -124,7 +131,7 @@ export class PushController {
   @ReturnedSchema(PushAcknowledgmentSwagger)
   async sendTestPush(
     @Param('installationId') installationId: string,
-    @Body('instance') instance: string = 'default',
+    @CoreBody('instance') instance: string = 'default',
   ): Promise<{ installationId: string; instance: string }> {
     await this.pushService.sendTestPush(installationId, instance);
     return { installationId, instance };

--- a/src/package/push/push.module.ts
+++ b/src/package/push/push.module.ts
@@ -1,4 +1,4 @@
-import { Module, ScheduleModule } from '@danet/core';
+import { Module } from '@danet/core';
 import { LoggerModule } from '@scope/logger';
 import { DatabaseModule } from '@scope/database';
 import { ExperimentModule } from '@scope/experiment';
@@ -17,7 +17,6 @@ import { PushRetryService } from './push-retry.service.ts';
     ExperimentModule,
     RateLimitModule,
     PushSenderModule,
-    ScheduleModule,
   ],
   controllers: [PushController],
   injectables: [

--- a/src/package/push/push.module.ts
+++ b/src/package/push/push.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@danet/core';
+import { Module, ScheduleModule } from '@danet/core';
 import { LoggerModule } from '@scope/logger';
 import { DatabaseModule } from '@scope/database';
 import { ExperimentModule } from '@scope/experiment';
@@ -7,6 +7,8 @@ import { PushSenderModule } from '@scope/service/push-sender';
 import { PushController } from './push.controller.ts';
 import { PushService } from './push.service.ts';
 import { PushRepository } from './push.repository.ts';
+import { PushDeliveryAttemptRepository } from './push-delivery-attempt.repository.ts';
+import { PushRetryService } from './push-retry.service.ts';
 
 @Module({
   imports: [
@@ -15,8 +17,14 @@ import { PushRepository } from './push.repository.ts';
     ExperimentModule,
     RateLimitModule,
     PushSenderModule,
+    ScheduleModule,
   ],
   controllers: [PushController],
-  injectables: [PushService, PushRepository],
+  injectables: [
+    PushService,
+    PushRepository,
+    PushDeliveryAttemptRepository,
+    PushRetryService,
+  ],
 })
 export class PushModule {}

--- a/src/package/push/push.repository.test.ts
+++ b/src/package/push/push.repository.test.ts
@@ -516,7 +516,10 @@ describe('PushRepository', () => {
       assertEquals(updated.status, 'pending');
       assertExists(updated.challenge);
       assertEquals(updated.challenge!.tokenHash, 'hash-abc123');
-      assertEquals(updated.challenge!.expiresAt, 1700100000);
+      assertEquals(
+        updated.challenge!.expiresAt.getTime(),
+        new Date(1700100000 * 1000).getTime(),
+      );
       assertEquals(updated.challenge!.attempts, 0);
     });
 
@@ -530,7 +533,7 @@ describe('PushRepository', () => {
           status: 'pending',
           challenge: {
             tokenHash: 'old-hash',
-            expiresAt: 1700000000,
+            expiresAt: new Date(1700000000 * 1000),
             attempts: 2,
           },
         }),
@@ -546,7 +549,10 @@ describe('PushRepository', () => {
       const updated = await repo.findById('ch-2', 'default');
       assertExists(updated);
       assertEquals(updated.challenge!.tokenHash, 'new-hash');
-      assertEquals(updated.challenge!.expiresAt, 1700200000);
+      assertEquals(
+        updated.challenge!.expiresAt.getTime(),
+        new Date(1700200000 * 1000).getTime(),
+      );
       assertEquals(updated.challenge!.attempts, 0);
     });
   });
@@ -663,93 +669,6 @@ describe('PushRepository', () => {
       // nowSeconds() may return the same value if both calls fall in the same second
       assert(updated.updatedAt >= original.updatedAt);
       assert(updated.updatedAt > 0);
-    });
-  });
-
-  describe('cleanupExpiredChallenges', () => {
-    it('deletes pending installations with expired challenges', async () => {
-      const repo = createRepo();
-
-      // Pending with expired challenge
-      await repo.upsert(
-        createPushDocument({
-          installationId: 'exp-ch-1',
-          instance: 'default',
-          status: 'pending',
-          challenge: {
-            tokenHash: 'h1',
-            expiresAt: 1000, // expired long ago
-            attempts: 1,
-          },
-        }),
-      );
-
-      // Pending with non-expired challenge
-      await repo.upsert(
-        createPushDocument({
-          installationId: 'valid-ch-1',
-          instance: 'default',
-          status: 'pending',
-          challenge: {
-            tokenHash: 'h2',
-            expiresAt: 3000, // still valid at t=2000
-            attempts: 0,
-          },
-        }),
-      );
-
-      // Active (should never be cleaned)
-      await repo.upsert(
-        createPushDocument({
-          installationId: 'active-1',
-          instance: 'default',
-          status: 'active',
-          challenge: {
-            tokenHash: 'h3',
-            expiresAt: 1000,
-            attempts: 3,
-          },
-        }),
-      );
-
-      const deletedCount = await repo.cleanupExpiredChallenges(2000);
-      assertEquals(deletedCount, 1);
-
-      // Verify the expired one is gone
-      const expired = await repo.findById('exp-ch-1', 'default');
-      assertEquals(expired, null);
-
-      // Verify the valid one still exists
-      const valid = await repo.findById('valid-ch-1', 'default');
-      assertExists(valid);
-
-      // Verify the active one still exists
-      const active = await repo.findById('active-1', 'default');
-      assertExists(active);
-    });
-
-    it('returns 0 when no expired challenges exist', async () => {
-      const repo = createRepo();
-
-      // Only non-expired
-      await repo.upsert(
-        createPushDocument({
-          installationId: 'always-valid',
-          instance: 'default',
-          status: 'pending',
-          challenge: {
-            tokenHash: 'h',
-            expiresAt: 9000,
-            attempts: 0,
-          },
-        }),
-      );
-
-      const deletedCount = await repo.cleanupExpiredChallenges(5000);
-      assertEquals(deletedCount, 0);
-
-      const still = await repo.findById('always-valid', 'default');
-      assertExists(still);
     });
   });
 });

--- a/src/package/push/push.repository.ts
+++ b/src/package/push/push.repository.ts
@@ -56,7 +56,7 @@ export interface PushInstallationDocument {
   };
   challenge?: {
     tokenHash: string;
-    expiresAt: number;
+    expiresAt: Date;
     attempts: number;
   };
   lastProfileSyncAt?: number;
@@ -241,7 +241,7 @@ export class PushRepository {
         $set: {
           challenge: {
             tokenHash,
-            expiresAt,
+            expiresAt: new Date(expiresAt * 1000),
             attempts: 0,
           },
           status: 'pending',
@@ -318,16 +318,5 @@ export class PushRepository {
         },
       },
     );
-  }
-
-  /**
-   * Delete installations with expired pending challenges.
-   */
-  async cleanupExpiredChallenges(now: number): Promise<number> {
-    const result = await this.collection.deleteMany({
-      status: 'pending',
-      'challenge.expiresAt': { $lt: now },
-    });
-    return result.deletedCount;
   }
 }

--- a/src/package/push/push.service.test.ts
+++ b/src/package/push/push.service.test.ts
@@ -8,6 +8,8 @@ import type {
   PushInstallationDocument,
   PushRepository,
 } from './push.repository.ts';
+import type { PushDeliveryAttemptRepository } from './push-delivery-attempt.repository.ts';
+import type { PushRetryService } from './push-retry.service.ts';
 import type { PushSenderService } from '@scope/service/push-sender';
 import type { SecretService } from '@scope/secret';
 import {
@@ -42,7 +44,9 @@ function makeDoc(
 function createService(
   deps: {
     repository?: Partial<PushRepository>;
+    deliveryRepo?: Partial<PushDeliveryAttemptRepository>;
     pushSender?: Partial<PushSenderService>;
+    retry?: Partial<PushRetryService>;
     secret?: SecretService;
   } = {},
 ): PushService {
@@ -50,7 +54,12 @@ function createService(
   const secret = deps.secret ?? createMockSecret({ DENO_ENV: 'test' }).service;
   return new PushService(
     (deps.repository ?? {}) as PushRepository,
+    (deps.deliveryRepo ?? {
+      insert: async () => {},
+      findByInstallation: async () => [],
+    }) as PushDeliveryAttemptRepository,
     (deps.pushSender ?? {}) as PushSenderService,
+    (deps.retry ?? { enqueue: async () => {} }) as PushRetryService,
     logger,
     secret,
   );
@@ -149,7 +158,11 @@ describe('PushService', () => {
     async () => {
       const doc = makeDoc({
         status: 'pending',
-        challenge: { tokenHash: 'old-hash', expiresAt: 1, attempts: 0 },
+        challenge: {
+          tokenHash: 'old-hash',
+          expiresAt: new Date(1 * 1000),
+          attempts: 0,
+        },
       });
       const repository = {
         findById: spy(async () => doc),

--- a/src/package/push/push.service.ts
+++ b/src/package/push/push.service.ts
@@ -2,12 +2,16 @@ import { Injectable } from '@danet/core';
 import { BadRequestException } from '@danet/core';
 import { LoggerService } from '@scope/logger';
 import { SecretService } from '@scope/secret';
+import type { PushNotificationPayload } from '@scope/service/push-sender';
+import type { PushSubscription } from '@scope/service/push-sender';
 import { PushSenderService } from '@scope/service/push-sender';
 import { validatePushEndpoint } from '@scope/common/ssrf';
 import {
   type PushInstallationDocument,
   PushRepository,
 } from './push.repository.ts';
+import { PushDeliveryAttemptRepository } from './push-delivery-attempt.repository.ts';
+import { PushRetryService } from './push-retry.service.ts';
 import {
   PushChallengeExpiredError,
   PushChallengeInvalidError,
@@ -35,7 +39,9 @@ export class PushService {
 
   constructor(
     private readonly repository: PushRepository,
+    private readonly deliveryRepo: PushDeliveryAttemptRepository,
     private readonly pushSender: PushSenderService,
+    private readonly retry: PushRetryService,
     private readonly logger: LoggerService,
     private readonly secret: SecretService,
   ) {
@@ -120,8 +126,8 @@ export class PushService {
     const result = await this.repository.upsert(doc);
 
     // Generate challenge token
-    const token = this.generateChallengeToken();
-    const tokenHash = await this.hashToken(token);
+    const token = this.generateChallenge();
+    const tokenHash = await this.sha256(token);
     const expiresAt = now + this.challengeTtlSeconds;
 
     // Store challenge
@@ -138,15 +144,18 @@ export class PushService {
         endpoint: registration.endpoint,
         keys: registration.keys,
       });
-      await this.pushSender.send(
+      await this.deliver(
         subscriber,
         registration.endpoint,
+        registration,
         {
           type: 'push.challenge',
           id: crypto.randomUUID(),
           token,
         },
         result.installationId,
+        result.instance,
+        'push.challenge',
       );
     } catch (error) {
       // Log but don't fail registration — challenge can be retried
@@ -201,12 +210,12 @@ export class PushService {
 
     // Check expiry
     const now = this.nowSeconds();
-    if (installation.challenge.expiresAt < now) {
+    if (installation.challenge.expiresAt.getTime() < now * 1000) {
       throw new PushChallengeExpiredError(installationId);
     }
 
     // Verify token
-    const submittedHash = await this.hashToken(confirmation.token);
+    const submittedHash = await this.sha256(confirmation.token);
     if (submittedHash !== installation.challenge.tokenHash) {
       this.logger.instance.warn(
         `Invalid challenge token for installation ${installationId}`,
@@ -384,22 +393,25 @@ export class PushService {
       keys: installation.keys,
     });
 
-    const result = await this.pushSender.send(
+    const { success, gone } = await this.deliver(
       subscriber,
       installation.endpoint,
+      { endpoint: installation.endpoint, keys: installation.keys },
       {
         type: 'push.test',
         id: crypto.randomUUID(),
         createdAt: Date.now(),
       },
       installationId,
+      instance,
+      'push.test',
     );
 
-    if (result.gone) {
+    if (gone) {
       await this.repository.markExpired(installationId, instance);
     }
 
-    return { success: result.success };
+    return { success };
   }
 
   // --- Fan-Out (news) ---
@@ -432,21 +444,24 @@ export class PushService {
           keys: installation.keys,
         });
 
-        const result = await this.pushSender.send(
+        const { success, gone } = await this.deliver(
           subscriber,
           installation.endpoint,
+          { endpoint: installation.endpoint, keys: installation.keys },
           payload,
           installation.installationId,
+          installation.instance,
+          'news.available',
         );
 
-        if (result.gone) {
+        if (gone) {
           await this.repository.markExpired(
             installation.installationId,
             installation.instance,
           );
         }
 
-        if (result.success) sent++;
+        if (success) sent++;
         else failed++;
       } catch (error) {
         failed++;
@@ -466,7 +481,74 @@ export class PushService {
 
   // --- Helpers ---
 
-  private generateChallengeToken(): string {
+  /**
+   * Send a push notification and persist the delivery outcome.
+   *
+   * Persistence is fire-and-forget: a failure to record the
+   * attempt does not affect the returned delivery result.
+   */
+  private async deliver(
+    subscriber: ReturnType<PushSenderService['subscribe']>,
+    endpoint: string,
+    subscription: PushSubscription,
+    payload: Record<string, unknown>,
+    installationId: string,
+    instance: string,
+    type: string,
+  ): Promise<{ success: boolean; gone: boolean }> {
+    const result = await this.pushSender.send(
+      subscriber,
+      endpoint,
+      payload as PushNotificationPayload,
+      installationId,
+    );
+
+    // Fire-and-forget: record the delivery attempt
+    this.deliveryRepo.insert({
+      installationId,
+      instance,
+      endpointHash: await this.sha256(endpoint),
+      type,
+      id: (payload as { id: string }).id ?? '',
+      success: result.success,
+      gone: result.gone,
+      statusCode: result.statusCode,
+      error: result.error,
+      latencyMs: result.latencyMs,
+      attemptedAt: new Date(),
+    }).catch((error) => {
+      this.logger.instance.warn(
+        'Failed to persist delivery attempt',
+        { cause: error },
+      );
+    });
+
+    // Enqueue retry for retryable failures
+    if (!result.success && !result.gone) {
+      const retryable = !result.statusCode ||
+        result.statusCode === 429 ||
+        result.statusCode >= 500;
+      if (retryable) {
+        this.retry.enqueue({
+          installationId,
+          instance,
+          endpoint,
+          keys: subscription.keys,
+          payload,
+          type,
+        }).catch((error) => {
+          this.logger.instance.warn(
+            'Failed to enqueue retry',
+            { cause: error },
+          );
+        });
+      }
+    }
+
+    return { success: result.success, gone: result.gone };
+  }
+
+  private generateChallenge(): string {
     const bytes = new Uint8Array(32);
     crypto.getRandomValues(bytes);
     return btoa(String.fromCharCode(...bytes))
@@ -475,9 +557,9 @@ export class PushService {
       .replace(/=+$/, '');
   }
 
-  private async hashToken(token: string): Promise<string> {
+  private async sha256(input: string): Promise<string> {
     const encoder = new TextEncoder();
-    const data = encoder.encode(token);
+    const data = encoder.encode(input);
     const hash = await crypto.subtle.digest('SHA-256', data);
     return btoa(String.fromCharCode(...new Uint8Array(hash)));
   }


### PR DESCRIPTION
## Description

Follow-up to #395. Addresses the remaining items from #378.

### What's included

- **@Body schema wiring**: All 5 mutation endpoints now use `@danet/zod` `Body` decorators with swagger schemas, giving runtime Zod validation and OpenAPI request body documentation
- **Delivery attempt persistence**: New `PushDeliveryAttemptRepository` records every push outcome (success, failure, gone) to `push_delivery_attempts` with 90-day TTL auto-cleanup
- **Redis-based retry service**: `PushRetryService` with capped exponential backoff (0s → 1m → 5m → 30m) for retryable failures (429, 5xx, timeout). Uses manual `setInterval` polling to avoid ScheduleModule Swagger crash
- **TTL index fix**: `expiresAt` and `attemptedAt` now stored as `Date` objects (were plain numbers — MongoDB TTL background process silently ignored them)
- **Dead code removal**: Removed `cleanupExpiredChallenges()` (TTL index handles this) and ghost `idx_delivery_status` index on non-existent `status` field
- **Code fixes**: Renamed `hashToken` → `sha256`, fixed `InMemoryCollection` Date sorting

### What's NOT included (separate PRs)

- Link/unlink endpoints (`PUT profile` already handles identity via `identity` block)
- Structured observability (spec at `.slim/deepwork/378-push-observability-spec.md`)

### Quality Gates

| Gate | Result |
|------|--------|
| deno fmt --check | ✓ 325 files |
| deno lint | ✓ 313 files, 0 errors |
| deno task check | ✓ |
| deno task test | ✓ 94 passed, 0 failed, 4 ignored |
| swagger:generate | ✓ |
| swagger:validate | ✓ |

Ref: #378